### PR TITLE
Add listening history chart to results page

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import os
 import re
 import time
 import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from threading import Lock, Thread
 from math import ceil
 from datetime import datetime, timezone, timedelta
@@ -1208,12 +1209,52 @@ def history():
     )
 
 
+LISTENING_HISTORY_CACHE: dict[str, dict] = {}
+LISTENING_HISTORY_CACHE_LOCK = Lock()
+LISTENING_HISTORY_CACHE_TTL_SECONDS = 30 * 60
+LISTENING_HISTORY_MAX_WORKERS = 6
+
+
+def _listening_history_cache_key(username: str, track: str, artist: str, months: int) -> str:
+    return "|".join([
+        normalize_lastfm_text(username),
+        normalize_lastfm_text(track),
+        normalize_lastfm_text(artist),
+        str(months),
+    ])
+
+
+def _fetch_week_plays(
+    username: str, week: dict, norm_track: str, norm_artist: str
+) -> int:
+    """Fetch a single weekly track chart and return the play count for the target track."""
+    try:
+        weekly_data = lastfm_get(
+            "user.getWeeklyTrackChart",
+            user=username,
+            **{"from": week["from"], "to": week["to"]},
+        )
+    except Exception:
+        return 0
+
+    week_tracks = weekly_data.get("weeklytrackchart", {}).get("track", [])
+    if isinstance(week_tracks, dict):
+        week_tracks = [week_tracks]
+    for t in week_tracks:
+        t_name = normalize_lastfm_text(t.get("name", ""))
+        t_artist = normalize_lastfm_text(extract_artist_name(t.get("artist")))
+        if t_name == norm_track and t_artist == norm_artist:
+            return int(t.get("playcount", 0))
+    return 0
+
+
 @app.route("/api/listening-history")
 def listening_history():
     """Return monthly play counts for a track over the user's scrobble history.
 
     Uses the Last.fm weekly chart list to identify chart periods, then queries
-    weekly track charts to collect play counts, aggregated by calendar month.
+    weekly track charts **in parallel** to collect play counts, aggregated by
+    calendar month.  Results are cached for 30 minutes.
     """
     username = request.args.get("username", "").strip()
     track = request.args.get("track", "").strip()
@@ -1227,6 +1268,13 @@ def listening_history():
         max_months = min(int(months_param), 36)
     except (ValueError, TypeError):
         max_months = 12
+
+    # Check cache
+    cache_key = _listening_history_cache_key(username, track, artist, max_months)
+    with LISTENING_HISTORY_CACHE_LOCK:
+        cached = LISTENING_HISTORY_CACHE.get(cache_key)
+        if cached and time.time() - cached["ts"] < LISTENING_HISTORY_CACHE_TTL_SECONDS:
+            return jsonify(cached["data"])
 
     try:
         chart_list_data = lastfm_get("user.getWeeklyChartList", user=username)
@@ -1253,37 +1301,38 @@ def listening_history():
     norm_track = normalize_lastfm_text(track)
     norm_artist = normalize_lastfm_text(artist)
 
+    # Flatten all weeks across months for parallel fetching
+    week_jobs: list[tuple[str, dict]] = []
+    for month_key in sorted(monthly_weeks.keys()):
+        for week in monthly_weeks[month_key]:
+            week_jobs.append((month_key, week))
+
+    # Fetch weekly charts in parallel
+    month_plays: dict[str, int] = {mk: 0 for mk in monthly_weeks}
+    with ThreadPoolExecutor(max_workers=LISTENING_HISTORY_MAX_WORKERS) as pool:
+        future_to_month = {
+            pool.submit(_fetch_week_plays, username, week, norm_track, norm_artist): month_key
+            for month_key, week in week_jobs
+        }
+        for future in as_completed(future_to_month):
+            month_key = future_to_month[future]
+            try:
+                month_plays[month_key] += future.result()
+            except Exception:
+                pass
+
     result = []
     for month_key in sorted(monthly_weeks.keys()):
-        month_plays = 0
-        for week in monthly_weeks[month_key]:
-            try:
-                weekly_data = lastfm_get(
-                    "user.getWeeklyTrackChart",
-                    user=username,
-                    **{"from": week["from"], "to": week["to"]},
-                )
-            except Exception:
-                continue
-
-            week_tracks = weekly_data.get("weeklytrackchart", {}).get("track", [])
-            if isinstance(week_tracks, dict):
-                week_tracks = [week_tracks]
-            for t in week_tracks:
-                t_name = normalize_lastfm_text(t.get("name", ""))
-                t_artist = normalize_lastfm_text(
-                    extract_artist_name(t.get("artist"))
-                )
-                if t_name == norm_track and t_artist == norm_artist:
-                    month_plays += int(t.get("playcount", 0))
-                    break
-
         dt = datetime.strptime(month_key, "%Y-%m")
         result.append({
             "month": month_key,
             "label": dt.strftime("%b %Y"),
-            "plays": month_plays,
+            "plays": month_plays[month_key],
         })
+
+    # Store in cache
+    with LISTENING_HISTORY_CACHE_LOCK:
+        LISTENING_HISTORY_CACHE[cache_key] = {"data": result, "ts": time.time()}
 
     return jsonify(result)
 

--- a/app.py
+++ b/app.py
@@ -1208,5 +1208,85 @@ def history():
     )
 
 
+@app.route("/api/listening-history")
+def listening_history():
+    """Return monthly play counts for a track over the user's scrobble history.
+
+    Uses the Last.fm weekly chart list to identify chart periods, then queries
+    weekly track charts to collect play counts, aggregated by calendar month.
+    """
+    username = request.args.get("username", "").strip()
+    track = request.args.get("track", "").strip()
+    artist = request.args.get("artist", "").strip()
+    months_param = request.args.get("months", "12").strip()
+
+    if not username or not track or not artist:
+        return jsonify({"error": "username, track, and artist are required"}), 400
+
+    try:
+        max_months = min(int(months_param), 36)
+    except (ValueError, TypeError):
+        max_months = 12
+
+    try:
+        chart_list_data = lastfm_get("user.getWeeklyChartList", user=username)
+    except Exception:
+        return jsonify({"error": "Failed to fetch chart list from Last.fm"}), 502
+
+    charts = chart_list_data.get("weeklychartlist", {}).get("chart", [])
+    if not charts:
+        return jsonify([])
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=max_months * 31)
+    cutoff_ts = int(cutoff.timestamp())
+
+    # Group chart weeks into calendar months
+    monthly_weeks: dict[str, list[dict]] = {}
+    for chart in charts:
+        from_ts = int(chart.get("from", 0))
+        if from_ts < cutoff_ts:
+            continue
+        month_key = datetime.fromtimestamp(from_ts, tz=timezone.utc).strftime("%Y-%m")
+        monthly_weeks.setdefault(month_key, []).append(chart)
+
+    norm_track = normalize_lastfm_text(track)
+    norm_artist = normalize_lastfm_text(artist)
+
+    result = []
+    for month_key in sorted(monthly_weeks.keys()):
+        month_plays = 0
+        for week in monthly_weeks[month_key]:
+            try:
+                weekly_data = lastfm_get(
+                    "user.getWeeklyTrackChart",
+                    user=username,
+                    **{"from": week["from"], "to": week["to"]},
+                )
+            except Exception:
+                continue
+
+            week_tracks = weekly_data.get("weeklytrackchart", {}).get("track", [])
+            if isinstance(week_tracks, dict):
+                week_tracks = [week_tracks]
+            for t in week_tracks:
+                t_name = normalize_lastfm_text(t.get("name", ""))
+                t_artist = normalize_lastfm_text(
+                    extract_artist_name(t.get("artist"))
+                )
+                if t_name == norm_track and t_artist == norm_artist:
+                    month_plays += int(t.get("playcount", 0))
+                    break
+
+        dt = datetime.strptime(month_key, "%Y-%m")
+        result.append({
+            "month": month_key,
+            "label": dt.strftime("%b %Y"),
+            "plays": month_plays,
+        })
+
+    return jsonify(result)
+
+
 if __name__ == "__main__":
     app.run(debug=True, port=5000)

--- a/static/index.html
+++ b/static/index.html
@@ -1851,17 +1851,22 @@
         gradient.addColorStop(1, 'rgba(213, 16, 7, 0.08)');
 
         _listeningHistoryChart = new Chart(ctx, {
-          type: 'bar',
+          type: 'line',
           data: {
             labels,
             datasets: [{
               label: 'Plays',
               data: plays,
+              fill: true,
               backgroundColor: gradient,
               borderColor: 'rgba(213, 16, 7, 0.9)',
-              borderWidth: 1,
-              borderRadius: 4,
-              borderSkipped: false,
+              borderWidth: 2,
+              pointBackgroundColor: '#d51007',
+              pointBorderColor: '#fff',
+              pointBorderWidth: 1.5,
+              pointRadius: 4,
+              pointHoverRadius: 6,
+              tension: 0.35,
             }]
           },
           options: {

--- a/static/index.html
+++ b/static/index.html
@@ -42,6 +42,7 @@
     };
   </script>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
   <style>
     * {
       box-sizing: border-box;
@@ -592,6 +593,60 @@
       padding: 1.5rem;
       color: #d6d3d1;
       font-size: 1rem;
+    }
+
+    .listening-history-section {
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+      padding: 1.25rem 1.5rem 1.5rem;
+    }
+
+    .listening-history-header {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+
+    .listening-history-header .stat-icon {
+      width: 2.5rem;
+      flex-shrink: 0;
+      font-size: 1.4rem;
+      line-height: 1.8rem;
+      text-align: center;
+    }
+
+    .listening-history-header .stat-label {
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.12em;
+    }
+
+    .listening-history-chart-wrap {
+      position: relative;
+      width: 100%;
+      height: 200px;
+    }
+
+    .listening-history-loading {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      color: #a8a29e;
+      font-size: 0.85rem;
+      padding: 1rem 0;
+    }
+
+    .listening-history-loading .spinner {
+      width: 16px;
+      height: 16px;
+      border: 2px solid rgba(255,255,255,0.15);
+      border-top-color: #d51007;
+      border-radius: 50%;
+      animation: spin 0.7s linear infinite;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
     }
 
     .loading-screen {
@@ -1730,18 +1785,128 @@
               </div>
             </div>
           </div>
+          <div class="listening-history-section" id="listening-history-section">
+            <div class="listening-history-header">
+              <span class="stat-icon">📊</span>
+              <div>
+                <div class="stat-label">Listening history</div>
+              </div>
+            </div>
+            <div class="listening-history-loading" id="listening-history-loading">
+              <div class="spinner"></div>
+              <span>Loading listening history…</span>
+            </div>
+            <div class="listening-history-chart-wrap" id="listening-history-chart-wrap" style="display:none">
+              <canvas id="listening-history-chart"></canvas>
+            </div>
+          </div>
         `;
         resultCard.classList.add('show');
         resultCard.scrollIntoView({ behavior: 'smooth', block: 'start' });
         if (resultNeedsArtistFallback) {
           applyArtistFallback(document.getElementById('result-art'), data.artist);
         }
+        fetchAndRenderListeningHistory(data.track, data.artist);
         loadRecentSearches();
       } catch {
         _lookupResolve = null;
         stopLoadingAnimation();
         console.error('[lookup:error]', { username: currentUsername, track: track.name, artist: track.artist });
         showError('Something went wrong. Please try again.');
+      }
+    }
+
+    let _listeningHistoryChart = null;
+
+    async function fetchAndRenderListeningHistory(track, artist) {
+      const loadingEl = document.getElementById('listening-history-loading');
+      const chartWrap = document.getElementById('listening-history-chart-wrap');
+      const canvas = document.getElementById('listening-history-chart');
+      if (!loadingEl || !chartWrap || !canvas) return;
+
+      try {
+        const url = `/api/listening-history?username=${encodeURIComponent(currentUsername)}&track=${encodeURIComponent(track)}&artist=${encodeURIComponent(artist)}&months=12`;
+        const res = await fetch(url);
+        const historyData = await res.json();
+
+        if (!Array.isArray(historyData) || historyData.length === 0 || historyData.every(d => d.plays === 0)) {
+          loadingEl.innerHTML = '<span style="color:#78716c">No monthly listening data available.</span>';
+          return;
+        }
+
+        if (_listeningHistoryChart) {
+          _listeningHistoryChart.destroy();
+          _listeningHistoryChart = null;
+        }
+
+        loadingEl.style.display = 'none';
+        chartWrap.style.display = 'block';
+
+        const labels = historyData.map(d => d.label);
+        const plays = historyData.map(d => d.plays);
+
+        const ctx = canvas.getContext('2d');
+        const gradient = ctx.createLinearGradient(0, 0, 0, 200);
+        gradient.addColorStop(0, 'rgba(213, 16, 7, 0.7)');
+        gradient.addColorStop(1, 'rgba(213, 16, 7, 0.08)');
+
+        _listeningHistoryChart = new Chart(ctx, {
+          type: 'bar',
+          data: {
+            labels,
+            datasets: [{
+              label: 'Plays',
+              data: plays,
+              backgroundColor: gradient,
+              borderColor: 'rgba(213, 16, 7, 0.9)',
+              borderWidth: 1,
+              borderRadius: 4,
+              borderSkipped: false,
+            }]
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: { display: false },
+              tooltip: {
+                backgroundColor: 'rgba(30, 27, 58, 0.95)',
+                titleColor: '#fff',
+                bodyColor: '#d6d3d1',
+                borderColor: 'rgba(255,255,255,0.1)',
+                borderWidth: 1,
+                cornerRadius: 8,
+                padding: 10,
+                callbacks: {
+                  label: ctx => `${ctx.parsed.y} play${ctx.parsed.y !== 1 ? 's' : ''}`,
+                },
+              },
+            },
+            scales: {
+              x: {
+                ticks: { color: '#78716c', font: { size: 11 }, maxRotation: 45 },
+                grid: { display: false },
+                border: { display: false },
+              },
+              y: {
+                beginAtZero: true,
+                ticks: {
+                  color: '#78716c',
+                  font: { size: 11 },
+                  stepSize: 1,
+                  precision: 0,
+                },
+                grid: { color: 'rgba(255,255,255,0.04)' },
+                border: { display: false },
+              },
+            },
+          },
+        });
+      } catch (err) {
+        console.error('[listening-history:error]', err);
+        if (loadingEl) {
+          loadingEl.innerHTML = '<span style="color:#78716c">Could not load listening history.</span>';
+        }
       }
     }
 

--- a/test_app.py
+++ b/test_app.py
@@ -45,6 +45,8 @@ def isolated_db(tmp_path):
         database.init_db()
         with app_module.LOOKUP_PROGRESS_LOCK:
             app_module.LOOKUP_PROGRESS.clear()
+        with app_module.LISTENING_HISTORY_CACHE_LOCK:
+            app_module.LISTENING_HISTORY_CACHE.clear()
         yield db_file
 
 
@@ -843,3 +845,29 @@ class TestListeningHistory:
             assert len(data) >= 1
             assert data[0]["plays"] == 0
 
+    def test_cached_response_avoids_api_calls(self, client):
+        """Second request for the same track should be served from cache."""
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        from_ts = int(month_start.timestamp())
+        to_ts = from_ts + 7 * 86400
+
+        api_calls = [0]
+
+        def fake_get(method, **kwargs):
+            api_calls[0] += 1
+            if method == "user.getWeeklyChartList":
+                return _weekly_chart_list([(from_ts, to_ts)])
+            return _weekly_track_chart([("CachedSong", "CachedArtist", 5)])
+
+        with patch("app.lastfm_get", side_effect=fake_get):
+            resp1 = client.get("/api/listening-history?username=cacheuser&track=CachedSong&artist=CachedArtist&months=2")
+            assert resp1.status_code == 200
+            calls_after_first = api_calls[0]
+
+            resp2 = client.get("/api/listening-history?username=cacheuser&track=CachedSong&artist=CachedArtist&months=2")
+            assert resp2.status_code == 200
+            assert api_calls[0] == calls_after_first, "Second request should not trigger new API calls"
+            assert resp1.get_json() == resp2.get_json()

--- a/test_app.py
+++ b/test_app.py
@@ -756,3 +756,90 @@ class TestHistory:
             assert data[0]["track"] == "Track Beta", "Higher id must always sort first for equal timestamps"
             assert data[1]["track"] == "Track Alpha"
 
+
+# ---------------------------------------------------------------------------
+# /api/listening-history
+# ---------------------------------------------------------------------------
+
+class TestListeningHistory:
+    """Tests for the listening-history endpoint."""
+
+    def test_missing_params_returns_400(self, client):
+        resp = client.get("/api/listening-history?username=u&track=t")
+        assert resp.status_code == 400
+
+    def test_empty_chart_list_returns_empty(self, client):
+        with patch("app.lastfm_get") as mock_get:
+            mock_get.return_value = {"weeklychartlist": {"chart": []}}
+            resp = client.get("/api/listening-history?username=u&track=Song&artist=Band")
+            assert resp.status_code == 200
+            assert resp.get_json() == []
+
+    def test_returns_monthly_play_counts(self, client):
+        import calendar
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+        # Build 4 chart weeks within the current month
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        weeks = []
+        for i in range(4):
+            from_ts = int(month_start.timestamp()) + i * 7 * 86400
+            to_ts = from_ts + 7 * 86400
+            weeks.append((from_ts, to_ts))
+
+        chart_list = _weekly_chart_list(weeks)
+        weekly_chart_with_track = _weekly_track_chart([("MySong", "MyArtist", 3)])
+        weekly_chart_empty = _weekly_track_chart([("OtherSong", "OtherArtist", 5)])
+
+        def fake_get(method, **kwargs):
+            if method == "user.getWeeklyChartList":
+                return chart_list
+            if method == "user.getWeeklyTrackChart":
+                # Return matching track for first two weeks, empty for the rest
+                from_val = int(kwargs.get("from", 0))
+                if from_val in (weeks[0][0], weeks[1][0]):
+                    return weekly_chart_with_track
+                return weekly_chart_empty
+            return {}
+
+        with patch("app.lastfm_get", side_effect=fake_get):
+            resp = client.get("/api/listening-history?username=u&track=MySong&artist=MyArtist&months=2")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert len(data) >= 1
+            month_key = month_start.strftime("%Y-%m")
+            entry = next((d for d in data if d["month"] == month_key), None)
+            assert entry is not None
+            assert entry["plays"] == 6  # 3 plays × 2 weeks
+            assert "label" in entry
+
+    def test_chart_list_api_failure_returns_502(self, client):
+        with patch("app.lastfm_get", side_effect=Exception("API down")):
+            resp = client.get("/api/listening-history?username=u&track=t&artist=a")
+            assert resp.status_code == 502
+
+    def test_weekly_chart_failure_still_returns_data(self, client):
+        """If individual weekly chart calls fail, the month should still appear with 0 plays."""
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+        month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        from_ts = int(month_start.timestamp())
+        to_ts = from_ts + 7 * 86400
+
+        call_count = [0]
+
+        def fake_get(method, **kwargs):
+            if method == "user.getWeeklyChartList":
+                return _weekly_chart_list([(from_ts, to_ts)])
+            call_count[0] += 1
+            raise Exception("chart fetch failed")
+
+        with patch("app.lastfm_get", side_effect=fake_get):
+            resp = client.get("/api/listening-history?username=u&track=t&artist=a&months=2")
+            assert resp.status_code == 200
+            data = resp.get_json()
+            assert len(data) >= 1
+            assert data[0]["plays"] == 0
+


### PR DESCRIPTION
## Summary

Adds a monthly listening history bar chart to the track result card, showing how often the user listened to a song over the last 12 months.

### What's new

- **`/api/listening-history` endpoint** — aggregates Last.fm weekly chart data into monthly play counts for a given track/artist/user. Accepts an optional `months` parameter (default 12, max 36).
- **Chart.js bar chart** — rendered inside the result card with ember-themed gradient styling, dark tooltips, and a responsive layout. Shows a loading spinner while data is fetched.
- **5 new tests** covering parameter validation, empty charts, monthly aggregation, API failures, and graceful degradation.

### How it works

1. Fetches the user's weekly chart list from Last.fm
2. Groups chart periods by calendar month (within the requested range)
3. For each week in each month, queries `user.getWeeklyTrackChart` and sums plays for the matching track
4. Returns a JSON array of `{month, label, plays}` objects

### Screenshot area

The chart appears below the existing stats (first listen date, time ago, scrobble count) as a new "📊 Listening history" section.