### PR TITLE
add spotify auth option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,18 @@ DB_PATH=timetraveler.db
 # Alternatively, use endpoint + key instead of a connection string:
 # COSMOS_ENDPOINT=http://localhost:8081/
 # COSMOS_KEY=<emulator-key>
+
+# ---- Spotify OAuth -----------------------------------------------------------
+# Register an app at https://developer.spotify.com/dashboard. Copy the client
+# id and secret here, and add the redirect URI to the app's "Redirect URIs".
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+# Must exactly match the Redirect URI registered with Spotify.
+# Local dev:  http://127.0.0.1:5000/api/spotify/callback
+# Production: https://<your-app>.azurecontainerapps.io/api/spotify/callback
+SPOTIFY_REDIRECT_URI=http://127.0.0.1:5000/api/spotify/callback
+
+# 32-byte url-safe base64 key used to encrypt Spotify refresh tokens at rest.
+# Generate one with:
+#   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+SPOTIFY_TOKEN_ENCRYPTION_KEY=

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Connect either source (or both), type a song title, pick from the autocomplete s
 
 ## What's new
 
+- 🔐 **Log in with Spotify** — sign in via the Spotify OAuth flow (Authorization Code + PKCE). Your Spotify user id is your identity, so the same account on phone and desktop sees the same data. No passwords, no share links.
 - 🎧 **Spotify import** — upload your Spotify Extended Streaming History (`.json` files or the raw `.zip`) and the app uses your private play data as the **primary** source for first-listen lookups (instant, no API rate limits, complete history back to your first play).
-- 🔐 **Token-based auth** — Spotify uploads are protected by a per-profile secret token stored in a cookie. No passwords, no logins. The token's SHA-256 hash is what's stored on the server.
-- 🪞 **Dual-source search** — connect Spotify only, Last.fm only, or both. When both are connected, autocomplete merges results and Spotify takes priority (because it's faster and more complete).
+- 🔄 **One-click sync** — once logged in, click **Sync** to pull your last 50 plays from Spotify's `recently-played` API and append them to your imported history.
+- 🪞 **Dual-source search** — log into Spotify, connect Last.fm, or both. When both are connected, autocomplete merges results and Spotify takes priority (because it's faster and more complete).
 
 ## Architecture
 
@@ -86,13 +87,38 @@ or directly:
 pytest
 ```
 
-## Spotify import
+## Spotify
 
-### How to get your data
+### Setting up Spotify OAuth
+
+The app uses Spotify's [Authorization Code + PKCE](https://developer.spotify.com/documentation/web-api/tutorials/code-pkce-flow) flow with a server-side client secret. To enable it:
+
+1. Create a Spotify app at https://developer.spotify.com/dashboard.
+2. Copy the **Client ID** and **Client Secret** into your `.env` (`SPOTIFY_CLIENT_ID`, `SPOTIFY_CLIENT_SECRET`).
+3. Add a **Redirect URI** in the Spotify dashboard that exactly matches `SPOTIFY_REDIRECT_URI`. For local dev: `http://127.0.0.1:5000/api/spotify/callback`. For production: `https://<your-host>/api/spotify/callback`.
+4. Generate a Fernet key for encrypting refresh tokens at rest:
+   ```bash
+   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+   ```
+   Store the output as `SPOTIFY_TOKEN_ENCRYPTION_KEY`. **Keep this stable** — rotating it invalidates every stored refresh token (users will have to log in again).
+
+The OAuth scopes requested are `user-read-email user-read-recently-played`. If any of the four env vars above are missing the **Log in with Spotify** button is hidden and the auth endpoints return `503`.
+
+### Logging in & sync
+
+Click **Log in with Spotify** to start the OAuth flow. After you grant access you're redirected back and a `spotify_session` cookie (HttpOnly, `SameSite=Lax`, 30-day TTL) is set. The session id's SHA-256 hash is what's stored server-side; the raw cookie value never leaves your browser.
+
+Once logged in:
+- **Sync** calls Spotify's `/v1/me/player/recently-played` to fetch your last 50 plays and merges them into your imported history (deduplicated).
+- **Logout** removes the server-side session and clears the cookie.
+
+The sync API only returns the most recent 50 plays — for years of history use the GDPR export below.
+
+### How to import your full history (GDPR export)
 
 1. Log into https://www.spotify.com/account/privacy and request your **Extended Streaming History** (not the basic one — the extended export contains every play back to account creation, with full track metadata and play timestamps).
 2. Spotify emails you a download link within ~5 days. The download is a `.zip` containing one or more `Streaming_History_Audio_*.json` files.
-3. In the app, enter a display name (anything memorable — it's only used to label your data), then either drop the whole `.zip` in or select the individual `.json` files. Up to 500 MB per upload.
+3. In the app, log in with Spotify, then drop the whole `.zip` into the upload box or select the individual `.json` files. Up to 500 MB per upload.
 
 ### What gets imported
 
@@ -135,14 +161,11 @@ flowchart TD
   class done_lastfm,done_cache api
 ```
 
-### Disconnecting
+### Clearing data & logging out
 
-The "Clear & disconnect" button calls `DELETE /api/spotify/data?delete_profile=true`, which:
-
-- removes every play document from `spotify_plays` (all data for your `profile_id`),
-- removes your profile record from `spotify_profiles` (token hash + metadata).
-
-Both Cosmos containers are fully cleaned. There is no recovery once disconnected — your token cookie is also discarded.
+- **Clear data** (`DELETE /api/spotify/data`) removes every play document from `spotify_plays` for your profile but keeps your session and profile so you can re-upload.
+- **Logout** (`POST /api/spotify/logout`) deletes the server-side session record and clears the cookie. Your imported plays and profile remain — log in again with the same Spotify account to access them.
+- To fully purge a profile, log out and revoke the app from your Spotify account settings; the profile + plays expire automatically after the 90-day TTL on the Cosmos backend.
 
 ## Database
 
@@ -158,8 +181,9 @@ flowchart LR
 | Cosmos container | Partition key | Holds |
 |---|---|---|
 | `searches` | `/username_normalized` | Last.fm first-listen cache + per-artist first-listen cache |
-| `spotify_profiles` | `/profile_id_normalized` | One doc per Spotify user — display name + SHA-256 token hash |
+| `spotify_profiles` | `/profile_id_normalized` | One doc per Spotify user — display name + Fernet-encrypted refresh token + last-sync timestamp |
 | `spotify_plays` | `/profile_id_normalized` | One doc per Spotify play (deterministic SHA-1 ID for natural dedup) |
+| `spotify_sessions` | `/session_id_hash` | Server-side session records (SHA-256 of the session cookie value), 30-day TTL |
 
 Per-user partitioning means every Spotify query is a single-partition lookup — fast and RU-cheap.
 
@@ -230,6 +254,9 @@ You will be prompted for:
 - `AZURE_ENV_NAME` — a short name for this environment (e.g. `lastfm-prod`)
 - `AZURE_LOCATION` — Azure region (e.g. `eastus`)
 - `LASTFM_API_KEY` — your Last.fm API key (stored as a secret)
+- `SPOTIFY_CLIENT_ID` / `SPOTIFY_CLIENT_SECRET` — your Spotify app credentials (stored as secrets)
+- `SPOTIFY_REDIRECT_URI` — must be `https://<your-host>/api/spotify/callback` and registered in the Spotify dashboard
+- `SPOTIFY_TOKEN_ENCRYPTION_KEY` — a Fernet key (see [Spotify](#spotify))
 
 The Cosmos connection string is wired into the Container App as a secret reference — you don't need to set it manually.
 
@@ -255,6 +282,10 @@ The `.github/workflows/azure-aca-deploy.yml` workflow runs `azd provision` and `
 | `AZURE_ENV_NAME` | Variable | azd environment name |
 | `AZURE_LOCATION` | Variable | Azure region (e.g. `eastus`) |
 | `LASTFM_API_KEY` | **Secret** | Last.fm API key |
+| `SPOTIFY_CLIENT_ID` | Variable | Spotify app client id |
+| `SPOTIFY_CLIENT_SECRET` | **Secret** | Spotify app client secret |
+| `SPOTIFY_REDIRECT_URI` | Variable | OAuth callback URL (`https://<host>/api/spotify/callback`) |
+| `SPOTIFY_TOKEN_ENCRYPTION_KEY` | **Secret** | Fernet key for encrypting refresh tokens at rest |
 
 To set up federated credentials (OIDC) for the service principal, follow the [azd GitHub Actions guide](https://learn.microsoft.com/azure/developer/azure-developer-cli/configure-devops-pipeline).
 
@@ -287,9 +318,13 @@ To set up federated credentials (OIDC) for the service principal, follow the [az
 | `GET /api/artist-first-listen?artist=&username=&profile_id=` | First time a user heard any track by the given artist |
 | `GET /api/history?username=` | All cached first-listen results for the given Last.fm username |
 | `GET /api/listening-history?username=&track=&artist=` | Per-week play counts for a track (Last.fm only) |
-| `POST /api/spotify/upload` | Multipart upload of `.json` / `.zip` Spotify history files. First upload issues a token. |
-| `GET /api/spotify/status?profile_id=` | Verify token and report import stats |
-| `DELETE /api/spotify/data?profile_id=&delete_profile=true` | Clear imported plays; with `delete_profile=true` also deletes the profile + token |
-| `GET /api/spotify/search?profile_id=&q=` | Autocomplete over the user's imported Spotify tracks |
+| `GET /api/spotify/login` | Start the OAuth flow (302 redirect to Spotify) |
+| `GET /api/spotify/callback` | OAuth callback — exchanges the auth code for tokens and creates a session |
+| `POST /api/spotify/logout` | Delete the server-side session and clear the cookie |
+| `GET /api/spotify/status` | Reports `logged_in`, profile id, display name, and import stats |
+| `POST /api/spotify/upload` | Multipart upload of `.json` / `.zip` Spotify history files (session required) |
+| `POST /api/spotify/sync` | Pull the last 50 plays from Spotify's `recently-played` and append them |
+| `DELETE /api/spotify/data` | Clear imported plays for the logged-in user |
+| `GET /api/spotify/search?q=` | Autocomplete over the user's imported Spotify tracks |
 
-All `/api/spotify/*` endpoints (except the initial upload that creates a profile) require the `spotify_token` cookie or `X-Spotify-Token` header.
+All `/api/spotify/*` endpoints (except `login`, `callback`, and `status`) require a valid `spotify_session` cookie.

--- a/app.py
+++ b/app.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone, timedelta
 from urllib.parse import quote, unquote
 from zoneinfo import ZoneInfo
 import requests
-from flask import Flask, abort, jsonify, request, send_from_directory
+from flask import Flask, abort, jsonify, redirect as _flask_redirect, request, send_from_directory
 from dotenv import load_dotenv
 import database as db
 
@@ -42,10 +42,21 @@ SPOTIFY_FILENAME_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Spotify token cookie / header names.
-SPOTIFY_TOKEN_COOKIE = "spotify_token"
-SPOTIFY_TOKEN_HEADER = "X-Spotify-Token"
-SPOTIFY_PROFILE_COOKIE = "spotify_profile_id"
+# ---- Spotify OAuth ---------------------------------------------------------
+# Identity is the Spotify user id, returned by /me. After the OAuth handshake
+# we issue an opaque random session id and store its SHA-256 hash server-side
+# (see database.create_spotify_session). The browser keeps only the cookie.
+SPOTIFY_SESSION_COOKIE = "spotify_session"
+SPOTIFY_SESSION_COOKIE_MAX_AGE = 30 * 24 * 60 * 60  # 30 days, matches DB TTL
+SPOTIFY_OAUTH_AUTHORIZE_URL = "https://accounts.spotify.com/authorize"
+SPOTIFY_OAUTH_TOKEN_URL = "https://accounts.spotify.com/api/token"
+SPOTIFY_API_BASE = "https://api.spotify.com/v1"
+SPOTIFY_OAUTH_SCOPES = "user-read-email user-read-recently-played"
+SPOTIFY_OAUTH_STATE_TTL_SECONDS = 10 * 60
+SPOTIFY_CLIENT_ID = (os.getenv("SPOTIFY_CLIENT_ID") or "").strip()
+SPOTIFY_CLIENT_SECRET = (os.getenv("SPOTIFY_CLIENT_SECRET") or "").strip()
+SPOTIFY_REDIRECT_URI = (os.getenv("SPOTIFY_REDIRECT_URI") or "").strip()
+SPOTIFY_TOKEN_ENCRYPTION_KEY = (os.getenv("SPOTIFY_TOKEN_ENCRYPTION_KEY") or "").strip()
 
 app = Flask(__name__, static_folder="static")
 app.config["MAX_CONTENT_LENGTH"] = MAX_UPLOAD_BYTES
@@ -931,27 +942,179 @@ def _find_and_store_artist_first_listen(username: str, artist: str) -> dict:
 # Spotify Extended Streaming History support
 # ---------------------------------------------------------------------------
 
+# Pending OAuth state -> code_verifier (PKCE). Lives in memory only; if a
+# worker is killed mid-flow the user just retries login.
+SPOTIFY_OAUTH_PENDING: dict[str, dict] = {}
+SPOTIFY_OAUTH_PENDING_LOCK = Lock()
 
-def _hash_spotify_token(token: str) -> str:
-    return hashlib.sha256((token or "").encode("utf-8")).hexdigest()
+# Per-user access-token cache. Single-worker gunicorn (--workers 1) means a
+# plain dict is safe; if scaled out, drop this and refresh per request.
+SPOTIFY_ACCESS_TOKENS: dict[str, dict] = {}
+SPOTIFY_ACCESS_TOKENS_LOCK = Lock()
 
 
-def _read_spotify_token_from_request() -> str:
-    token = request.headers.get(SPOTIFY_TOKEN_HEADER, "").strip()
-    if token:
-        return token
-    return (request.cookies.get(SPOTIFY_TOKEN_COOKIE, "") or "").strip()
+def _spotify_oauth_configured() -> bool:
+    return bool(
+        SPOTIFY_CLIENT_ID
+        and SPOTIFY_CLIENT_SECRET
+        and SPOTIFY_REDIRECT_URI
+        and SPOTIFY_TOKEN_ENCRYPTION_KEY
+    )
 
 
-def _verify_spotify_access(profile_id: str) -> bool:
-    """Return True if the request carries a valid token for *profile_id*.
+def _fernet():
+    """Lazily build a Fernet instance from the configured key."""
+    from cryptography.fernet import Fernet  # imported lazily to keep import-time light
+    return Fernet(SPOTIFY_TOKEN_ENCRYPTION_KEY.encode("utf-8"))
 
-    Aborts with 403 otherwise.
+
+def _encrypt_refresh_token(token: str) -> str:
+    if not token:
+        return ""
+    return _fernet().encrypt(token.encode("utf-8")).decode("ascii")
+
+
+def _decrypt_refresh_token(token_encrypted: str) -> str:
+    if not token_encrypted:
+        return ""
+    return _fernet().decrypt(token_encrypted.encode("ascii")).decode("utf-8")
+
+
+def _spotify_pkce_pair() -> tuple[str, str]:
+    """Return (code_verifier, code_challenge) per RFC 7636."""
+    import base64
+    verifier = secrets.token_urlsafe(64)[:128]
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+def _cleanup_oauth_states(now: float | None = None) -> None:
+    now = now or time.time()
+    expired = [
+        s for s, payload in SPOTIFY_OAUTH_PENDING.items()
+        if now - payload.get("created_at", 0) > SPOTIFY_OAUTH_STATE_TTL_SECONDS
+    ]
+    for s in expired:
+        SPOTIFY_OAUTH_PENDING.pop(s, None)
+
+
+def _read_spotify_session_id() -> str:
+    return (request.cookies.get(SPOTIFY_SESSION_COOKIE) or "").strip()
+
+
+def _current_spotify_user() -> str | None:
+    """Return the logged-in Spotify user id, or None."""
+    sid = _read_spotify_session_id()
+    if not sid:
+        return None
+    return db.verify_spotify_session(sid)
+
+
+def _require_spotify_session() -> str:
+    """Return the logged-in Spotify user id or abort with 401."""
+    profile_id = _current_spotify_user()
+    if not profile_id:
+        abort(401, description="Spotify login required.")
+    return profile_id
+
+
+def _spotify_request_token(payload: dict) -> dict:
+    """POST to Spotify's token endpoint and return the JSON response.
+
+    Uses HTTP Basic for client_id:client_secret per the Authorization Code flow.
     """
-    token = _read_spotify_token_from_request()
-    if not token or not db.verify_spotify_token(profile_id, _hash_spotify_token(token)):
-        abort(403, description="Invalid or missing Spotify profile token.")
-    return True
+    import base64
+    auth = base64.b64encode(
+        f"{SPOTIFY_CLIENT_ID}:{SPOTIFY_CLIENT_SECRET}".encode("utf-8")
+    ).decode("ascii")
+    resp = requests.post(
+        SPOTIFY_OAUTH_TOKEN_URL,
+        data=payload,
+        headers={
+            "Authorization": f"Basic {auth}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        timeout=15,
+    )
+    if resp.status_code != 200:
+        app.logger.warning("spotify token endpoint returned %s: %s", resp.status_code, resp.text[:300])
+        try:
+            body = resp.json()
+        except Exception:
+            body = {"error": "token_exchange_failed", "error_description": resp.text[:200]}
+        raise requests.HTTPError(body, response=resp)
+    return resp.json()
+
+
+def _get_valid_access_token(profile_id: str) -> str:
+    """Return a fresh access token for *profile_id*, refreshing if needed."""
+    now = time.time()
+    with SPOTIFY_ACCESS_TOKENS_LOCK:
+        cached = SPOTIFY_ACCESS_TOKENS.get(profile_id)
+        if cached and cached.get("expires_at", 0) - 60 > now:
+            return cached["access_token"]
+    profile = db.get_spotify_profile(profile_id)
+    if not profile:
+        abort(401, description="Spotify profile not found.")
+    enc = profile.get("refresh_token_encrypted") or ""
+    if not enc:
+        abort(401, description="No refresh token on file. Please re-login with Spotify.")
+    refresh_token = _decrypt_refresh_token(enc)
+    token_resp = _spotify_request_token({
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+    })
+    access_token = token_resp.get("access_token") or ""
+    expires_in = int(token_resp.get("expires_in") or 3600)
+    if not access_token:
+        abort(502, description="Spotify did not return an access token.")
+    # Spotify may rotate the refresh token; persist if so.
+    new_refresh = token_resp.get("refresh_token")
+    if new_refresh and new_refresh != refresh_token:
+        db.update_spotify_refresh_token(profile_id, _encrypt_refresh_token(new_refresh))
+    with SPOTIFY_ACCESS_TOKENS_LOCK:
+        SPOTIFY_ACCESS_TOKENS[profile_id] = {
+            "access_token": access_token,
+            "expires_at": now + expires_in,
+        }
+    return access_token
+
+
+def _spotify_play_from_recently_played_item(item: dict) -> dict | None:
+    """Convert one /me/player/recently-played item to our play-row dict."""
+    if not isinstance(item, dict):
+        return None
+    track = item.get("track") or {}
+    name = track.get("name")
+    artists = track.get("artists") or []
+    artist = (artists[0] or {}).get("name") if artists else None
+    if not name or not artist:
+        return None
+    album = ((track.get("album") or {}).get("name")) or ""
+    played_at = item.get("played_at") or ""
+    if not played_at:
+        return None
+    try:
+        ts_norm = played_at.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(ts_norm)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        played_at_unix = int(dt.timestamp())
+    except (TypeError, ValueError):
+        return None
+    duration_ms = int(track.get("duration_ms") or 0)
+    return {
+        "track": name,
+        "artist": artist,
+        "album": album,
+        "played_at": played_at,
+        "played_at_unix": played_at_unix,
+        # The recent-plays endpoint doesn't report ms_played; assume the full
+        # track. This keeps these rows above SPOTIFY_MIN_MS_PLAYED for the
+        # filter that runs on uploads (sync-imported rows don't filter).
+        "ms_played": max(duration_ms, SPOTIFY_MIN_MS_PLAYED),
+    }
 
 
 def _spotify_play_from_entry(entry: dict) -> dict | None:
@@ -1159,6 +1322,14 @@ def _forbidden_json(exc):
     return exc
 
 
+@app.errorhandler(401)
+def _unauthorized_json(exc):
+    if request.path.startswith("/api/"):
+        description = getattr(exc, "description", None) or "Authentication required."
+        return jsonify({"ok": False, "error": description}), 401
+    return exc
+
+
 @app.errorhandler(500)
 def _server_error_json(exc):
     """Return a JSON 500 for /api/ routes so the UI can surface a useful message."""
@@ -1198,114 +1369,160 @@ def _unhandled_exception_json(exc):
     }), 500
 
 
+def _redirect(location: str):
+    return _flask_redirect(location, code=302)
+
+
+@app.route("/api/spotify/login")
+def spotify_login():
+    """Kick off the Authorization Code + PKCE flow."""
+    if not _spotify_oauth_configured():
+        return jsonify({
+            "ok": False,
+            "error": "Spotify login is not configured on this server.",
+        }), 503
+    state = secrets.token_urlsafe(32)
+    verifier, challenge = _spotify_pkce_pair()
+    with SPOTIFY_OAUTH_PENDING_LOCK:
+        _cleanup_oauth_states()
+        SPOTIFY_OAUTH_PENDING[state] = {
+            "code_verifier": verifier,
+            "created_at": time.time(),
+        }
+    from urllib.parse import urlencode
+    params = urlencode({
+        "client_id": SPOTIFY_CLIENT_ID,
+        "response_type": "code",
+        "redirect_uri": SPOTIFY_REDIRECT_URI,
+        "scope": SPOTIFY_OAUTH_SCOPES,
+        "state": state,
+        "code_challenge_method": "S256",
+        "code_challenge": challenge,
+        # Force the consent screen on every login so the user can pick
+        # a different account if they want to.
+        "show_dialog": "true",
+    })
+    return _redirect(f"{SPOTIFY_OAUTH_AUTHORIZE_URL}?{params}")
+
+
+@app.route("/api/spotify/callback")
+def spotify_callback():
+    """Exchange the auth code for tokens, fetch /me, create a session."""
+    if not _spotify_oauth_configured():
+        return jsonify({"ok": False, "error": "Spotify login is not configured."}), 503
+    error = (request.args.get("error") or "").strip()
+    if error:
+        return _redirect(f"/?spotify_error={quote(error)}")
+    code = (request.args.get("code") or "").strip()
+    state = (request.args.get("state") or "").strip()
+    if not code or not state:
+        return jsonify({"ok": False, "error": "Missing code or state."}), 400
+    with SPOTIFY_OAUTH_PENDING_LOCK:
+        _cleanup_oauth_states()
+        pending = SPOTIFY_OAUTH_PENDING.pop(state, None)
+    if not pending:
+        return jsonify({
+            "ok": False,
+            "error": "OAuth state is unknown or expired. Please retry login.",
+        }), 400
+    try:
+        token_resp = _spotify_request_token({
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": SPOTIFY_REDIRECT_URI,
+            "code_verifier": pending["code_verifier"],
+        })
+    except requests.HTTPError as exc:
+        body = exc.args[0] if exc.args else {}
+        return jsonify({
+            "ok": False,
+            "error": "Spotify rejected the authorization code.",
+            "spotify_error": body if isinstance(body, dict) else str(body),
+        }), 400
+    access_token = token_resp.get("access_token") or ""
+    refresh_token = token_resp.get("refresh_token") or ""
+    scopes = token_resp.get("scope") or SPOTIFY_OAUTH_SCOPES
+    if not access_token or not refresh_token:
+        return jsonify({"ok": False, "error": "Spotify did not return both tokens."}), 502
+    me = requests.get(
+        f"{SPOTIFY_API_BASE}/me",
+        headers={"Authorization": f"Bearer {access_token}"},
+        timeout=15,
+    )
+    if me.status_code != 200:
+        return jsonify({
+            "ok": False,
+            "error": f"Could not fetch Spotify profile: HTTP {me.status_code}",
+        }), 502
+    me_json = me.json()
+    spotify_user_id = (me_json.get("id") or "").strip()
+    if not spotify_user_id:
+        return jsonify({"ok": False, "error": "Spotify /me response had no user id."}), 502
+    images = me_json.get("images") or []
+    avatar_url = (images[0].get("url") if images else "") or ""
+    db.upsert_spotify_profile(
+        spotify_user_id,
+        display_name=me_json.get("display_name") or spotify_user_id,
+        avatar_url=avatar_url,
+        refresh_token_encrypted=_encrypt_refresh_token(refresh_token),
+        scopes=scopes,
+    )
+    # Cache this access token under the user id so the immediate first
+    # request to a Spotify-backed endpoint avoids a refresh round-trip.
+    expires_in = int(token_resp.get("expires_in") or 3600)
+    with SPOTIFY_ACCESS_TOKENS_LOCK:
+        SPOTIFY_ACCESS_TOKENS[spotify_user_id] = {
+            "access_token": access_token,
+            "expires_at": time.time() + expires_in,
+        }
+    session_id = secrets.token_urlsafe(32)
+    db.create_spotify_session(spotify_user_id, session_id)
+    resp = _redirect("/")
+    # HttpOnly so client-side JS can't read it (defense against XSS).
+    # SameSite=Lax allows cross-site GET navigation back from accounts.spotify.com.
+    resp.set_cookie(
+        SPOTIFY_SESSION_COOKIE,
+        session_id,
+        max_age=SPOTIFY_SESSION_COOKIE_MAX_AGE,
+        secure=request.is_secure,
+        httponly=True,
+        samesite="Lax",
+        path="/",
+    )
+    return resp
+
+
+@app.route("/api/spotify/logout", methods=["POST"])
+def spotify_logout():
+    sid = _read_spotify_session_id()
+    if sid:
+        db.delete_spotify_session(sid)
+    resp = jsonify({"ok": True})
+    resp.delete_cookie(SPOTIFY_SESSION_COOKIE, path="/")
+    return resp
+
+
 @app.route("/api/spotify/upload", methods=["POST"])
 def spotify_upload():
     """Import Spotify Extended Streaming History from JSON or ZIP files.
 
     Multipart form fields:
-      - profile_id: user-chosen display name
       - files: one or more uploaded files (.json or .zip)
+
+    Identity comes from the session cookie set by /api/spotify/callback.
+    Spotify user id (returned by /me) is the partition key for all stored
+    data, so the same Spotify login on any device sees the same imports.
 
     The actual parse + DB import happens in a background thread because
     large libraries can easily take longer than Azure Container Apps' ingress
-    timeout (~4 min). This endpoint:
-      1. Validates the request and the upload size.
-      2. Streams uploaded files to temp files on disk.
-      3. Issues a token if the profile is brand new.
-      4. Spawns a worker thread and returns HTTP 202 with `{job_id}`.
-
-    The client polls `/api/spotify/import-progress?job_id=` for status.
+    timeout (~4 min). Returns HTTP 202 + `{job_id}`; client polls
+    /api/spotify/import-progress for status.
     """
-    profile_id = (request.form.get("profile_id") or "").strip()
-    if not profile_id:
-        return jsonify({"ok": False, "error": "profile_id is required"}), 400
-    if len(profile_id) > 80:
-        return jsonify({"ok": False, "error": "profile_id is too long (max 80 chars)"}), 400
+    profile_id = _require_spotify_session()
 
     files = request.files.getlist("files")
     if not files:
         return jsonify({"ok": False, "error": "At least one file is required"}), 400
-
-    profile_exists = db.spotify_profile_exists(profile_id)
-    # Two recovery paths for stranded profiles where the original uploader can
-    # no longer prove ownership:
-    #
-    #   1. Empty profile  → user disconnected/cleared and lost their token.
-    #      The profile row exists but has zero plays, so nothing of value is
-    #      lost by re-claiming it.
-    #
-    #   2. Never-accessed profile (the "504 orphan") → a previous upload
-    #      created the profile and started writing plays, but the response
-    #      (containing the token cookie) never reached the client because
-    #      ingress timed out. We can detect this because no one has ever
-    #      authenticated successfully against the profile (Cosmos backend
-    #      tracks `last_accessed_at` separately from `created_at`).
-    #
-    # In both cases the recovery only fires if the request lacks a valid token
-    # — anyone with the correct token can keep re-uploading normally.
-    if profile_exists:
-        token = _read_spotify_token_from_request()
-        token_ok = bool(token) and db.verify_spotify_token(profile_id, _hash_spotify_token(token))
-        if not token_ok:
-            try:
-                empty = not db.has_spotify_data(profile_id)
-                never_accessed = not db.spotify_profile_was_accessed(profile_id)
-            except Exception as exc:
-                app.logger.exception(
-                    "spotify upload: failed to inspect profile profile_id=%r", profile_id,
-                )
-                return jsonify({
-                    "ok": False,
-                    "error": f"Could not check existing profile: {exc}",
-                    "exception_type": exc.__class__.__name__,
-                }), 500
-            if empty or never_accessed:
-                try:
-                    if not empty:
-                        # Wipe the orphaned plays so the new uploader starts clean.
-                        app.logger.info(
-                            "spotify upload reclaiming orphan profile profile_id=%r",
-                            profile_id,
-                        )
-                        db.clear_spotify_data(profile_id)
-                    db.delete_spotify_profile(profile_id)
-                except Exception as exc:
-                    app.logger.exception(
-                        "spotify upload: failed to reclaim orphan profile profile_id=%r",
-                        profile_id,
-                    )
-                    return jsonify({
-                        "ok": False,
-                        "error": (
-                            "Could not re-claim the existing profile with that name. "
-                            f"Try a different display name. (Underlying error: {exc})"
-                        ),
-                        "exception_type": exc.__class__.__name__,
-                    }), 500
-                profile_exists = False
-
-    is_new_profile = not profile_exists
-    issued_token = ""
-    if is_new_profile:
-        issued_token = secrets.token_urlsafe(32)
-        try:
-            db.create_spotify_profile(profile_id, _hash_spotify_token(issued_token))
-        except Exception as exc:
-            app.logger.exception("failed to create spotify profile profile_id=%r", profile_id)
-            return jsonify({"ok": False, "error": f"Could not create profile: {exc}"}), 500
-    else:
-        # Profile exists with data and the request has a valid token (we
-        # already checked above). Re-verify here so the standard 403 path
-        # still triggers if something went wrong between the checks.
-        token = _read_spotify_token_from_request()
-        if not token or not db.verify_spotify_token(profile_id, _hash_spotify_token(token)):
-            return jsonify({
-                "ok": False,
-                "error": (
-                    f"The display name '{profile_id}' is already in use by a different upload. "
-                    "Pick a different name, or click Disconnect first if this is your data."
-                ),
-            }), 403
 
     # Stream uploads to temp files so the worker thread can read them after
     # the request has returned. We accept .json and .zip; anything else is
@@ -1339,7 +1556,6 @@ def spotify_upload():
                 tmp.close()
             saved.append((f.filename, tmp.name, is_zip))
     except Exception as exc:
-        # Clean up anything we wrote so far, then surface the error.
         for _, path, _is_zip in saved:
             try:
                 os.unlink(path)
@@ -1373,36 +1589,12 @@ def spotify_upload():
     )
     worker.start()
 
-    response_body = {
+    resp = jsonify({
         "ok": True,
         "job_id": job_id,
-        "profile_id": profile_id,
         "files_queued": len(saved),
-    }
-    if issued_token:
-        response_body["token"] = issued_token
-    resp = jsonify(response_body)
+    })
     resp.status_code = 202
-    if issued_token:
-        # Persist the token + profile id in cookies so a returning visitor can
-        # auto-reconnect without re-uploading.
-        max_age = 365 * 24 * 60 * 60
-        resp.set_cookie(
-            SPOTIFY_TOKEN_COOKIE,
-            issued_token,
-            max_age=max_age,
-            samesite="Lax",
-            httponly=False,
-            path="/",
-        )
-        resp.set_cookie(
-            SPOTIFY_PROFILE_COOKIE,
-            profile_id,
-            max_age=max_age,
-            samesite="Lax",
-            httponly=False,
-            path="/",
-        )
     return resp
 
 
@@ -1449,7 +1641,6 @@ def _run_spotify_import_job(job_id: str, profile_id: str, saved: list[tuple[str,
             active=False,
             error=str(exc) or exc.__class__.__name__,
         )
-        # Make sure any remaining temp files are cleaned up.
         for _, path, _is_zip in saved:
             try:
                 os.unlink(path)
@@ -1470,56 +1661,106 @@ def _run_spotify_import_job(job_id: str, profile_id: str, saved: list[tuple[str,
 @app.route("/api/spotify/import-progress")
 def spotify_import_progress():
     """Poll endpoint for an in-flight Spotify import job."""
+    profile_id = _require_spotify_session()
     job_id = (request.args.get("job_id") or "").strip()
     if not job_id:
         return jsonify({"ok": False, "error": "job_id is required"}), 400
     payload = get_spotify_import_job(job_id)
     if payload is None:
         return jsonify({"ok": False, "error": "Unknown or expired job_id"}), 404
+    # Only the owning user can see their own job.
+    if payload.get("profile_id") and payload["profile_id"] != profile_id:
+        return jsonify({"ok": False, "error": "Job belongs to a different user."}), 403
     payload["ok"] = True
     return jsonify(payload)
 
 
 @app.route("/api/spotify/status")
 def spotify_status():
-    profile_id = (request.args.get("profile_id") or "").strip()
+    """Return the current login state and (if logged in) profile + stats."""
+    profile_id = _current_spotify_user()
     if not profile_id:
-        return jsonify({"ok": False, "error": "profile_id is required"}), 400
-    if not db.spotify_profile_exists(profile_id):
-        return jsonify({"ok": False, "error": "Profile not found"}), 404
-    _verify_spotify_access(profile_id)
+        return jsonify({
+            "ok": True,
+            "logged_in": False,
+            "oauth_configured": _spotify_oauth_configured(),
+        })
+    profile = db.get_spotify_profile(profile_id) or {}
     return jsonify({
         "ok": True,
+        "logged_in": True,
+        "oauth_configured": True,
         "profile_id": profile_id,
+        "display_name": profile.get("display_name") or profile_id,
+        "avatar_url": profile.get("avatar_url") or "",
+        "last_sync_at": profile.get("last_sync_at") or "",
         "has_data": db.has_spotify_data(profile_id),
+        "stats": db.get_spotify_stats(profile_id),
+    })
+
+
+@app.route("/api/spotify/sync", methods=["POST"])
+def spotify_sync():
+    """Pull the most-recent ~50 plays from Spotify and append them.
+
+    Spotify exposes only the last ~50 tracks via /me/player/recently-played,
+    so this is a top-up — the GDPR export upload is still the only path to
+    multi-year history. Deduplication uses the deterministic play-doc id.
+    """
+    profile_id = _require_spotify_session()
+    access_token = _get_valid_access_token(profile_id)
+    resp = requests.get(
+        f"{SPOTIFY_API_BASE}/me/player/recently-played",
+        params={"limit": 50},
+        headers={"Authorization": f"Bearer {access_token}"},
+        timeout=15,
+    )
+    if resp.status_code == 401:
+        # Token invalidated between cache and call; clear and ask the user to retry.
+        with SPOTIFY_ACCESS_TOKENS_LOCK:
+            SPOTIFY_ACCESS_TOKENS.pop(profile_id, None)
+        return jsonify({"ok": False, "error": "Spotify rejected our token. Please retry."}), 401
+    if resp.status_code != 200:
+        return jsonify({
+            "ok": False,
+            "error": f"Spotify recently-played returned HTTP {resp.status_code}",
+        }), 502
+    items = (resp.json() or {}).get("items") or []
+    plays = []
+    filtered = 0
+    for it in items:
+        play = _spotify_play_from_recently_played_item(it)
+        if play:
+            plays.append(play)
+        else:
+            filtered += 1
+    inserted = db.save_spotify_plays(profile_id, plays) if plays else 0
+    db.update_spotify_last_sync(profile_id)
+    return jsonify({
+        "ok": True,
+        "fetched": len(items),
+        "imported": inserted,
+        "filtered": filtered,
         "stats": db.get_spotify_stats(profile_id),
     })
 
 
 @app.route("/api/spotify/data", methods=["DELETE"])
 def spotify_clear_data():
-    profile_id = (request.args.get("profile_id") or "").strip()
-    if not profile_id:
-        return jsonify({"ok": False, "error": "profile_id is required"}), 400
-    if not db.spotify_profile_exists(profile_id):
-        return jsonify({"ok": False, "error": "Profile not found"}), 404
-    _verify_spotify_access(profile_id)
+    profile_id = _require_spotify_session()
     delete_profile = (request.args.get("delete_profile") or "").lower() in ("1", "true", "yes")
     deleted = db.clear_spotify_data(profile_id)
     if delete_profile:
         db.delete_spotify_profile(profile_id)
+        with SPOTIFY_ACCESS_TOKENS_LOCK:
+            SPOTIFY_ACCESS_TOKENS.pop(profile_id, None)
     return jsonify({"ok": True, "deleted": deleted, "profile_deleted": delete_profile})
 
 
 @app.route("/api/spotify/search")
 def spotify_search():
-    profile_id = (request.args.get("profile_id") or "").strip()
+    profile_id = _require_spotify_session()
     query = (request.args.get("q") or "").strip()
-    if not profile_id:
-        return jsonify({"ok": False, "error": "profile_id is required"}), 400
-    if not db.spotify_profile_exists(profile_id):
-        return jsonify({"ok": False, "error": "Profile not found"}), 404
-    _verify_spotify_access(profile_id)
     if len(query) < 2:
         return jsonify([])
     rows = db.search_spotify_tracks(profile_id, query, limit=20)
@@ -2149,6 +2390,11 @@ def first_listen():
     username = request.args.get("username", "").strip()
     profile_id = request.args.get("profile_id", "").strip()
     hint_timestamp = request.args.get("hint_timestamp", "").strip() or None
+    # If the caller is logged in via Spotify OAuth, default profile_id to their
+    # session identity so the Spotify-first branch fires without needing the
+    # client to pass profile_id explicitly.
+    if not profile_id:
+        profile_id = _current_spotify_user() or ""
 
     if not track or not artist:
         finish_lookup_progress(
@@ -2177,27 +2423,27 @@ def first_listen():
     if not lookup_id:
         lookup_id = f"server-{int(time.time() * 1000)}"
 
-    # Spotify-first resolution: if a profile_id + valid token is supplied and
-    # the play exists in the imported history, return it immediately.
-    if profile_id and db.spotify_profile_exists(profile_id):
-        token = _read_spotify_token_from_request()
-        if token and db.verify_spotify_token(profile_id, _hash_spotify_token(token)):
-            spotify_payload = _spotify_first_listen_payload(profile_id, track, artist)
-            if spotify_payload:
-                spotify_payload["elapsed_ms"] = elapsed_ms()
-                finish_lookup_progress(
-                    lookup_id,
-                    profile_id=profile_id,
-                    artist=spotify_payload["artist"],
-                    track=spotify_payload["track"],
-                    stage="spotify-hit",
-                    status="Found in your Spotify history",
-                    detail="Returned the earliest play from your imported Spotify Extended Streaming History.",
-                    pages_checked=1,
-                    pages_total=1,
-                    result=spotify_payload,
-                )
-                return jsonify(spotify_payload)
+    # Spotify-first resolution: if the user is logged in via OAuth and the
+    # play exists in their imported history, return it immediately.
+    spotify_user = _current_spotify_user()
+    if spotify_user:
+        profile_id = spotify_user
+        spotify_payload = _spotify_first_listen_payload(profile_id, track, artist)
+        if spotify_payload:
+            spotify_payload["elapsed_ms"] = elapsed_ms()
+            finish_lookup_progress(
+                lookup_id,
+                profile_id=profile_id,
+                artist=spotify_payload["artist"],
+                track=spotify_payload["track"],
+                stage="spotify-hit",
+                status="Found in your Spotify history",
+                detail="Returned the earliest play from your imported Spotify Extended Streaming History.",
+                pages_checked=1,
+                pages_total=1,
+                result=spotify_payload,
+            )
+            return jsonify(spotify_payload)
 
     # If Last.fm is not connected we can't go further — return not found.
     if not username:
@@ -2426,6 +2672,8 @@ def artist_first_listen():
     username = request.args.get("username", "").strip()
     artist = request.args.get("artist", "").strip()
     profile_id = request.args.get("profile_id", "").strip()
+    if not profile_id:
+        profile_id = _current_spotify_user() or ""
 
     if not artist:
         return jsonify({"error": "artist is required"}), 400
@@ -2433,25 +2681,25 @@ def artist_first_listen():
         return jsonify({"error": "username or profile_id is required"}), 400
 
     # Spotify-first
-    if profile_id and db.spotify_profile_exists(profile_id):
-        token = _read_spotify_token_from_request()
-        if token and db.verify_spotify_token(profile_id, _hash_spotify_token(token)):
-            row = db.get_spotify_artist_first_listen(profile_id, artist)
-            if row:
-                ts = int(row.get("played_at_unix") or 0)
-                date_text = (
-                    datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%d %b %Y, %H:%M")
-                    if ts else (row.get("played_at") or "")
-                )
-                return jsonify({
-                    "artist": row.get("artist", artist),
-                    "username": username,
-                    "profile_id": profile_id,
-                    "first_listen_date": date_text,
-                    "first_listen_timestamp": str(ts) if ts else "",
-                    "first_listen_track": row.get("track", ""),
-                    "source": "spotify",
-                })
+    spotify_user = _current_spotify_user()
+    if spotify_user:
+        profile_id = spotify_user
+        row = db.get_spotify_artist_first_listen(profile_id, artist)
+        if row:
+            ts = int(row.get("played_at_unix") or 0)
+            date_text = (
+                datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%d %b %Y, %H:%M")
+                if ts else (row.get("played_at") or "")
+            )
+            return jsonify({
+                "artist": row.get("artist", artist),
+                "username": username,
+                "profile_id": profile_id,
+                "first_listen_date": date_text,
+                "first_listen_timestamp": str(ts) if ts else "",
+                "first_listen_track": row.get("track", ""),
+                "source": "spotify",
+            })
 
     if not username:
         return jsonify({

--- a/database.py
+++ b/database.py
@@ -16,7 +16,7 @@ import sqlite3
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 try:
     from azure.cosmos import CosmosClient, PartitionKey, exceptions as cosmos_exceptions
@@ -32,11 +32,14 @@ DEFAULT_COSMOS_DATABASE_NAME = "lastfm-timetraveler"
 DEFAULT_COSMOS_CONTAINER_NAME = "searches"
 COSMOS_SPOTIFY_PROFILES_CONTAINER = "spotify_profiles"
 COSMOS_SPOTIFY_PLAYS_CONTAINER = "spotify_plays"
+COSMOS_SPOTIFY_SESSIONS_CONTAINER = "spotify_sessions"
 SPOTIFY_BULK_INSERT_WORKERS = int(os.getenv("SPOTIFY_BULK_INSERT_WORKERS", "16"))
 # How often (seconds) to refresh a profile's TTL on access. The Cosmos
 # container has a 90-day TTL; touching less often than once a day would risk
 # expiry, more often is wasted writes.
 SPOTIFY_TOUCH_INTERVAL_SECONDS = int(os.getenv("SPOTIFY_TOUCH_INTERVAL_SECONDS", "3600"))
+# Sessions get a 30-day rolling TTL refreshed on every authenticated access.
+SPOTIFY_SESSION_TTL_SECONDS = int(os.getenv("SPOTIFY_SESSION_TTL_SECONDS", str(30 * 24 * 60 * 60)))
 SQLITE_TIMEOUT_SECONDS = 30
 INIT_DB_MAX_ATTEMPTS = 3
 INIT_DB_RETRY_DELAY_SECONDS = 0.25
@@ -115,6 +118,22 @@ def _is_locked_error(exc: sqlite3.OperationalError) -> bool:
 
 
 def _create_sqlite_schema(conn: sqlite3.Connection) -> None:
+    # Lightweight migration: the Spotify-OAuth rework changed the schema of
+    # spotify_profiles (token_hash -> refresh_token_encrypted) and added
+    # spotify_sessions. Older local DBs created before the rework still have
+    # the old shape, so drop the legacy spotify_* tables before re-creating
+    # them. (No production data exists for this branch — we already wiped
+    # the schema per the migration plan.)
+    try:
+        cols = [r[1] for r in conn.execute("PRAGMA table_info(spotify_profiles)").fetchall()]
+        if cols and "refresh_token_encrypted" not in cols:
+            conn.execute("DROP TABLE IF EXISTS spotify_profiles")
+            conn.execute("DROP TABLE IF EXISTS spotify_sessions")
+            conn.execute("DROP TABLE IF EXISTS spotify_history")
+    except sqlite3.DatabaseError:
+        # Brand-new DB or unreadable PRAGMA — nothing to migrate.
+        pass
+
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS searches (
@@ -159,10 +178,32 @@ def _create_sqlite_schema(conn: sqlite3.Connection) -> None:
     conn.execute(
         """
         CREATE TABLE IF NOT EXISTS spotify_profiles (
-            profile_id   TEXT PRIMARY KEY,
-            token_hash   TEXT NOT NULL,
-            created_at   TEXT NOT NULL
+            profile_id              TEXT PRIMARY KEY,
+            display_name            TEXT,
+            avatar_url              TEXT,
+            refresh_token_encrypted TEXT,
+            scopes                  TEXT,
+            created_at              TEXT NOT NULL,
+            last_login_at           TEXT,
+            last_sync_at            TEXT
         )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS spotify_sessions (
+            session_id_hash TEXT PRIMARY KEY,
+            profile_id      TEXT NOT NULL,
+            created_at      TEXT NOT NULL,
+            last_used_at    TEXT NOT NULL,
+            expires_at      TEXT NOT NULL
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_spotify_sessions_profile
+        ON spotify_sessions (LOWER(profile_id))
         """
     )
     conn.execute(
@@ -267,6 +308,10 @@ def _spotify_plays_container():
     return _get_cosmos_named_container(COSMOS_SPOTIFY_PLAYS_CONTAINER, "/profile_id_normalized")
 
 
+def _spotify_sessions_container():
+    return _get_cosmos_named_container(COSMOS_SPOTIFY_SESSIONS_CONTAINER, "/session_id_hash")
+
+
 def _spotify_play_doc_id(profile_id: str, played_at: str, track: str, artist: str) -> str:
     """Deterministic doc id matches the SQLite dedup index semantics."""
     raw = "|".join([
@@ -278,16 +323,27 @@ def _spotify_play_doc_id(profile_id: str, played_at: str, track: str, artist: st
     return hashlib.sha1(raw.encode("utf-8")).hexdigest()
 
 
-def _spotify_profile_doc(profile_id: str, token_hash: str) -> dict:
+def _spotify_profile_doc(
+    profile_id: str,
+    *,
+    display_name: str = "",
+    avatar_url: str = "",
+    refresh_token_encrypted: str = "",
+    scopes: str = "",
+) -> dict:
     now_iso = datetime.now(timezone.utc).isoformat()
     return {
         "id": _normalize_lookup_value(profile_id),
         "type": "spotify_profile",
         "profile_id": profile_id,
         "profile_id_normalized": _normalize_lookup_value(profile_id),
-        "token_hash": token_hash,
+        "display_name": display_name or "",
+        "avatar_url": avatar_url or "",
+        "refresh_token_encrypted": refresh_token_encrypted or "",
+        "scopes": scopes or "",
         "created_at": now_iso,
-        "last_accessed_at": now_iso,
+        "last_login_at": now_iso,
+        "last_sync_at": "",
     }
 
 
@@ -752,21 +808,149 @@ def save_artist_first_listen(
 # ---------------------------------------------------------------------------
 
 
-def create_spotify_profile(profile_id: str, token_hash: str) -> None:
-    """Create a new Spotify profile. Raises if it already exists."""
+def upsert_spotify_profile(
+    profile_id: str,
+    *,
+    display_name: str = "",
+    avatar_url: str = "",
+    refresh_token_encrypted: str = "",
+    scopes: str = "",
+) -> None:
+    """Create or update a Spotify profile keyed by Spotify user ID.
+
+    Existing rows have their `display_name`, `avatar_url`, `scopes` and
+    (if non-empty) `refresh_token_encrypted` refreshed; `created_at` is
+    preserved; `last_login_at` is bumped to now.
+    """
+    now_iso = datetime.now(timezone.utc).isoformat()
     if _use_cosmos_backend():
         container = _spotify_profiles_container()
+        normalized = _normalize_lookup_value(profile_id)
         try:
-            container.create_item(body=_spotify_profile_doc(profile_id, token_hash))
-        except cosmos_exceptions.CosmosResourceExistsError as exc:
-            raise ValueError(f"Spotify profile already exists: {profile_id}") from exc
+            existing = container.read_item(item=normalized, partition_key=normalized)
+        except cosmos_exceptions.CosmosResourceNotFoundError:
+            existing = None
+        if existing is None:
+            doc = _spotify_profile_doc(
+                profile_id,
+                display_name=display_name,
+                avatar_url=avatar_url,
+                refresh_token_encrypted=refresh_token_encrypted,
+                scopes=scopes,
+            )
+        else:
+            doc = existing
+            doc["display_name"] = display_name or doc.get("display_name", "")
+            doc["avatar_url"] = avatar_url or doc.get("avatar_url", "")
+            if scopes:
+                doc["scopes"] = scopes
+            if refresh_token_encrypted:
+                doc["refresh_token_encrypted"] = refresh_token_encrypted
+            doc["last_login_at"] = now_iso
+        container.upsert_item(body=doc)
         return
 
     _sqlite_init_db()
     with _sqlite_connect() as conn:
+        row = conn.execute(
+            "SELECT refresh_token_encrypted FROM spotify_profiles WHERE LOWER(profile_id) = LOWER(?)",
+            (profile_id,),
+        ).fetchone()
+        if row is None:
+            conn.execute(
+                """
+                INSERT INTO spotify_profiles
+                    (profile_id, display_name, avatar_url, refresh_token_encrypted,
+                     scopes, created_at, last_login_at, last_sync_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    profile_id,
+                    display_name or "",
+                    avatar_url or "",
+                    refresh_token_encrypted or "",
+                    scopes or "",
+                    now_iso,
+                    now_iso,
+                    "",
+                ),
+            )
+        else:
+            conn.execute(
+                """
+                UPDATE spotify_profiles
+                SET display_name            = COALESCE(NULLIF(?, ''), display_name),
+                    avatar_url              = COALESCE(NULLIF(?, ''), avatar_url),
+                    scopes                  = COALESCE(NULLIF(?, ''), scopes),
+                    refresh_token_encrypted = COALESCE(NULLIF(?, ''), refresh_token_encrypted),
+                    last_login_at           = ?
+                WHERE LOWER(profile_id) = LOWER(?)
+                """,
+                (display_name or "", avatar_url or "", scopes or "",
+                 refresh_token_encrypted or "", now_iso, profile_id),
+            )
+        conn.commit()
+
+
+def get_spotify_profile(profile_id: str) -> dict | None:
+    """Return the stored profile document, or None."""
+    if _use_cosmos_backend():
+        container = _spotify_profiles_container()
+        normalized = _normalize_lookup_value(profile_id)
+        try:
+            return container.read_item(item=normalized, partition_key=normalized)
+        except cosmos_exceptions.CosmosResourceNotFoundError:
+            return None
+
+    _sqlite_init_db()
+    with _sqlite_connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM spotify_profiles WHERE LOWER(profile_id) = LOWER(?)",
+            (profile_id,),
+        ).fetchone()
+    return dict(row) if row else None
+
+
+def update_spotify_refresh_token(profile_id: str, refresh_token_encrypted: str) -> None:
+    """Persist a rotated refresh token."""
+    if not refresh_token_encrypted:
+        return
+    if _use_cosmos_backend():
+        container = _spotify_profiles_container()
+        normalized = _normalize_lookup_value(profile_id)
+        try:
+            doc = container.read_item(item=normalized, partition_key=normalized)
+        except cosmos_exceptions.CosmosResourceNotFoundError:
+            return
+        doc["refresh_token_encrypted"] = refresh_token_encrypted
+        container.upsert_item(body=doc)
+        return
+    _sqlite_init_db()
+    with _sqlite_connect() as conn:
         conn.execute(
-            "INSERT INTO spotify_profiles (profile_id, token_hash, created_at) VALUES (?, ?, ?)",
-            (profile_id, token_hash, datetime.now(timezone.utc).isoformat()),
+            "UPDATE spotify_profiles SET refresh_token_encrypted = ? WHERE LOWER(profile_id) = LOWER(?)",
+            (refresh_token_encrypted, profile_id),
+        )
+        conn.commit()
+
+
+def update_spotify_last_sync(profile_id: str, when_iso: str | None = None) -> None:
+    when_iso = when_iso or datetime.now(timezone.utc).isoformat()
+    if _use_cosmos_backend():
+        container = _spotify_profiles_container()
+        normalized = _normalize_lookup_value(profile_id)
+        try:
+            doc = container.read_item(item=normalized, partition_key=normalized)
+        except cosmos_exceptions.CosmosResourceNotFoundError:
+            return
+        doc["last_sync_at"] = when_iso
+        container.upsert_item(body=doc)
+        return
+    _sqlite_init_db()
+    with _sqlite_connect() as conn:
+        conn.execute(
+            "UPDATE spotify_profiles SET last_sync_at = ? WHERE LOWER(profile_id) = LOWER(?)",
+            (when_iso, profile_id),
         )
         conn.commit()
 
@@ -790,92 +974,150 @@ def spotify_profile_exists(profile_id: str) -> bool:
     return row is not None
 
 
-def spotify_profile_was_accessed(profile_id: str) -> bool:
-    """Return True if the profile has ever been successfully verified.
+# ---- Sessions --------------------------------------------------------------
+# Sessions are server-side rows. The browser cookie carries only an opaque
+# random id whose SHA-256 hash is the document key; raw session ids are never
+# stored, so a DB leak alone cannot impersonate a user.
 
-    Used to detect the "504 orphan" scenario: when a previous upload created
-    the profile and issued a token but the response never reached the client
-    (e.g. ingress timeout), the profile exists but no one ever proved
-    ownership. In that case it's safe to let a fresh upload re-claim it.
+def _hash_session_id(session_id: str) -> str:
+    return hashlib.sha256((session_id or "").encode("utf-8")).hexdigest()
 
-    A profile counts as accessed iff `last_accessed_at` is present and
-    strictly later than `created_at`. The `verify_spotify_token` Cosmos
-    branch is responsible for keeping `last_accessed_at` fresh on every
-    authenticated request.
 
-    SQLite profiles are always considered accessed (the SQLite backend
-    doesn't track this and the local-dev workflow doesn't have the
-    timeout-orphan problem).
-    """
+def create_spotify_session(profile_id: str, session_id: str) -> None:
+    """Store a new session keyed by SHA-256(session_id)."""
+    now = datetime.now(timezone.utc)
+    expires_dt = now + timedelta(seconds=SPOTIFY_SESSION_TTL_SECONDS)
+    sid_hash = _hash_session_id(session_id)
+    doc = {
+        "id": sid_hash,
+        "session_id_hash": sid_hash,
+        "profile_id": profile_id,
+        "created_at": now.isoformat(),
+        "last_used_at": now.isoformat(),
+        "expires_at": expires_dt.isoformat(),
+    }
     if _use_cosmos_backend():
-        container = _spotify_profiles_container()
-        normalized = _normalize_lookup_value(profile_id)
-        try:
-            item = container.read_item(item=normalized, partition_key=normalized)
-        except cosmos_exceptions.CosmosResourceNotFoundError:
-            return False
-        last = (item.get("last_accessed_at") or "").strip()
-        created = (item.get("created_at") or "").strip()
-        if not last:
-            return False
-        return last != created
+        container = _spotify_sessions_container()
+        container.upsert_item(body=doc)
+        return
+    _sqlite_init_db()
+    with _sqlite_connect() as conn:
+        conn.execute(
+            """
+            INSERT OR REPLACE INTO spotify_sessions
+                (session_id_hash, profile_id, created_at, last_used_at, expires_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (sid_hash, profile_id, doc["created_at"], doc["last_used_at"], doc["expires_at"]),
+        )
+        conn.commit()
 
-    return True
 
+def verify_spotify_session(session_id: str) -> str | None:
+    """Return the profile_id (Spotify user id) for a valid session, or None.
 
-def verify_spotify_token(profile_id: str, token_hash: str) -> bool:
-    """Return True iff *(profile_id, token_hash)* matches a stored profile.
-
-    On a successful Cosmos verification, this also refreshes the profile's
-    `last_accessed_at` (and TTL) at most once per `SPOTIFY_TOUCH_INTERVAL_SECONDS`,
-    so active users never lose their data to the 90-day TTL.
+    Touches `last_used_at` and extends `expires_at` so active sessions don't
+    age out. Throttled by SPOTIFY_TOUCH_INTERVAL_SECONDS to limit writes.
     """
-    if not profile_id or not token_hash:
-        return False
+    if not session_id:
+        return None
+    sid_hash = _hash_session_id(session_id)
+    now = datetime.now(timezone.utc)
     if _use_cosmos_backend():
-        container = _spotify_profiles_container()
-        normalized = _normalize_lookup_value(profile_id)
+        container = _spotify_sessions_container()
         try:
-            item = container.read_item(item=normalized, partition_key=normalized)
+            doc = container.read_item(item=sid_hash, partition_key=sid_hash)
         except cosmos_exceptions.CosmosResourceNotFoundError:
-            return False
-        if (item.get("token_hash") or "") != token_hash:
-            return False
-        _maybe_touch_spotify_profile(container, item)
-        return True
+            return None
+        # Honor explicit expiry even if the Cosmos TTL hasn't reaped the doc yet.
+        expires_at = doc.get("expires_at") or ""
+        if expires_at:
+            try:
+                exp_dt = datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+                if exp_dt < now:
+                    return None
+            except ValueError:
+                pass
+        last_used = doc.get("last_used_at") or doc.get("created_at") or ""
+        should_touch = True
+        if last_used:
+            try:
+                last_dt = datetime.fromisoformat(last_used.replace("Z", "+00:00"))
+                if (now - last_dt).total_seconds() < SPOTIFY_TOUCH_INTERVAL_SECONDS:
+                    should_touch = False
+            except ValueError:
+                pass
+        if should_touch:
+            doc["last_used_at"] = now.isoformat()
+            doc["expires_at"] = (now + timedelta(seconds=SPOTIFY_SESSION_TTL_SECONDS)).isoformat()
+            try:
+                container.upsert_item(body=doc)
+            except Exception:  # noqa: BLE001
+                pass
+        return doc.get("profile_id") or None
 
     _sqlite_init_db()
     with _sqlite_connect() as conn:
         row = conn.execute(
-            "SELECT token_hash FROM spotify_profiles WHERE LOWER(profile_id) = LOWER(?)",
-            (profile_id,),
+            "SELECT profile_id, expires_at, last_used_at FROM spotify_sessions WHERE session_id_hash = ?",
+            (sid_hash,),
         ).fetchone()
-    if not row:
-        return False
-    return (row["token_hash"] or "") == token_hash
-
-
-def _maybe_touch_spotify_profile(container, item: dict) -> None:
-    """Refresh `last_accessed_at` on the profile doc to extend its TTL.
-
-    Throttled by `SPOTIFY_TOUCH_INTERVAL_SECONDS` so we don't write on every
-    request. Failures are silently swallowed — the worst case is the profile
-    expires after 90 days of inactivity, which is the desired behavior anyway.
-    """
-    now = datetime.now(timezone.utc)
-    last = item.get("last_accessed_at") or item.get("created_at") or ""
-    if last:
+        if not row:
+            return None
         try:
-            last_dt = datetime.fromisoformat(last.replace("Z", "+00:00"))
-            if (now - last_dt).total_seconds() < SPOTIFY_TOUCH_INTERVAL_SECONDS:
-                return
+            exp_dt = datetime.fromisoformat((row["expires_at"] or "").replace("Z", "+00:00"))
+            if exp_dt < now:
+                return None
         except ValueError:
+            return None
+        new_exp = (now + timedelta(seconds=SPOTIFY_SESSION_TTL_SECONDS)).isoformat()
+        conn.execute(
+            "UPDATE spotify_sessions SET last_used_at = ?, expires_at = ? WHERE session_id_hash = ?",
+            (now.isoformat(), new_exp, sid_hash),
+        )
+        conn.commit()
+        return row["profile_id"]
+
+
+def delete_spotify_session(session_id: str) -> None:
+    if not session_id:
+        return
+    sid_hash = _hash_session_id(session_id)
+    if _use_cosmos_backend():
+        container = _spotify_sessions_container()
+        try:
+            container.delete_item(item=sid_hash, partition_key=sid_hash)
+        except cosmos_exceptions.CosmosResourceNotFoundError:
             pass
-    item["last_accessed_at"] = now.isoformat()
-    try:
-        container.upsert_item(body=item)
-    except Exception:  # noqa: BLE001 — best-effort, never block the request
-        pass
+        return
+    _sqlite_init_db()
+    with _sqlite_connect() as conn:
+        conn.execute("DELETE FROM spotify_sessions WHERE session_id_hash = ?", (sid_hash,))
+        conn.commit()
+
+
+def delete_all_spotify_sessions(profile_id: str) -> None:
+    """Revoke every session for *profile_id* (used during account-clear / logout-everywhere)."""
+    if _use_cosmos_backend():
+        container = _spotify_sessions_container()
+        items = list(container.query_items(
+            query="SELECT c.id, c.session_id_hash FROM c WHERE c.profile_id = @p",
+            parameters=[{"name": "@p", "value": profile_id}],
+            enable_cross_partition_query=True,
+        ))
+        for it in items:
+            try:
+                container.delete_item(item=it["id"], partition_key=it["session_id_hash"])
+            except cosmos_exceptions.CosmosResourceNotFoundError:
+                pass
+        return
+    _sqlite_init_db()
+    with _sqlite_connect() as conn:
+        conn.execute(
+            "DELETE FROM spotify_sessions WHERE LOWER(profile_id) = LOWER(?)",
+            (profile_id,),
+        )
+        conn.commit()
 
 
 def save_spotify_plays(profile_id: str, plays: list[dict]) -> int:
@@ -1130,6 +1372,7 @@ def clear_spotify_data(profile_id: str) -> int:
 
 
 def delete_spotify_profile(profile_id: str) -> None:
+    delete_all_spotify_sessions(profile_id)
     if _use_cosmos_backend():
         clear_spotify_data(profile_id)
         profiles = _spotify_profiles_container()

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -13,6 +13,20 @@ param location string
 @secure()
 param lastfmApiKey string = ''
 
+@description('Spotify OAuth client id.')
+param spotifyClientId string = ''
+
+@description('Spotify OAuth client secret.')
+@secure()
+param spotifyClientSecret string = ''
+
+@description('Spotify OAuth redirect URI (must match the Spotify app dashboard).')
+param spotifyRedirectUri string = ''
+
+@description('Fernet key (url-safe base64) used to encrypt Spotify refresh tokens.')
+@secure()
+param spotifyTokenEncryptionKey string = ''
+
 var tags = { 'azd-env-name': environmentName }
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 
@@ -31,6 +45,10 @@ module resources 'resources.bicep' = {
     tags: tags
     resourceToken: resourceToken
     lastfmApiKey: lastfmApiKey
+    spotifyClientId: spotifyClientId
+    spotifyClientSecret: spotifyClientSecret
+    spotifyRedirectUri: spotifyRedirectUri
+    spotifyTokenEncryptionKey: spotifyTokenEncryptionKey
   }
 }
 

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -10,6 +10,18 @@
     },
     "lastfmApiKey": {
       "value": "${LASTFM_API_KEY}"
+    },
+    "spotifyClientId": {
+      "value": "${SPOTIFY_CLIENT_ID}"
+    },
+    "spotifyClientSecret": {
+      "value": "${SPOTIFY_CLIENT_SECRET}"
+    },
+    "spotifyRedirectUri": {
+      "value": "${SPOTIFY_REDIRECT_URI}"
+    },
+    "spotifyTokenEncryptionKey": {
+      "value": "${SPOTIFY_TOKEN_ENCRYPTION_KEY}"
     }
   }
 }

--- a/infra/resources.bicep
+++ b/infra/resources.bicep
@@ -15,6 +15,20 @@ param resourceToken string
 @secure()
 param lastfmApiKey string = ''
 
+@description('Spotify OAuth client id (https://developer.spotify.com/dashboard).')
+param spotifyClientId string = ''
+
+@description('Spotify OAuth client secret stored as a Container App secret.')
+@secure()
+param spotifyClientSecret string = ''
+
+@description('Spotify OAuth redirect URI. Must match a value registered in the Spotify app dashboard.')
+param spotifyRedirectUri string = ''
+
+@description('Fernet key (32-byte url-safe base64) used to encrypt Spotify refresh tokens at rest.')
+@secure()
+param spotifyTokenEncryptionKey string = ''
+
 var normalizedEnvironmentName = toLower(replace(replace(environmentName, '_', '-'), ' ', '-'))
 var compactEnvironmentName = take(toLower(replace(replace(replace(replace(environmentName, '-', ''), '_', ''), ' ', ''), '.', '')), 41)
 var acrName = 'acr${compactEnvironmentName}${take(resourceToken, 6)}'
@@ -163,6 +177,25 @@ resource cosmosSpotifyPlaysContainer 'Microsoft.DocumentDB/databaseAccounts/sqlD
   }
 }
 
+resource cosmosSpotifySessionsContainer 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-11-15' = {
+  name: 'spotify_sessions'
+  parent: cosmosDatabase
+  properties: {
+    resource: {
+      id: 'spotify_sessions'
+      partitionKey: {
+        paths: [
+          '/session_id_hash'
+        ]
+        kind: 'Hash'
+        version: 2
+      }
+      // 30-day rolling TTL refreshed on each authenticated request.
+      defaultTtl: 2592000
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Container Apps Environment
 // ---------------------------------------------------------------------------
@@ -192,6 +225,7 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
     cosmosContainer
     cosmosSpotifyProfilesContainer
     cosmosSpotifyPlaysContainer
+    cosmosSpotifySessionsContainer
   ]
   properties: {
     managedEnvironmentId: containerAppsEnvironment.id
@@ -221,6 +255,14 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
           name: 'cosmos-connection-string'
           value: cosmosAccount.listConnectionStrings().connectionStrings[0].connectionString
         }
+        {
+          name: 'spotify-client-secret'
+          value: spotifyClientSecret
+        }
+        {
+          name: 'spotify-token-encryption-key'
+          value: spotifyTokenEncryptionKey
+        }
       ]
     }
     template: {
@@ -245,6 +287,22 @@ resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
             {
               name: 'COSMOS_CONTAINER_NAME'
               value: cosmosContainerName
+            }
+            {
+              name: 'SPOTIFY_CLIENT_ID'
+              value: spotifyClientId
+            }
+            {
+              name: 'SPOTIFY_CLIENT_SECRET'
+              secretRef: 'spotify-client-secret'
+            }
+            {
+              name: 'SPOTIFY_REDIRECT_URI'
+              value: spotifyRedirectUri
+            }
+            {
+              name: 'SPOTIFY_TOKEN_ENCRYPTION_KEY'
+              secretRef: 'spotify-token-encryption-key'
             }
           ]
           resources: {

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ requests==2.33.1
 python-dotenv==1.2.2
 gunicorn==25.3.0
 azure-cosmos==4.15.0
+cryptography==46.0.4
 pytest==9.0.3
 ijson==3.5.0

--- a/static/index.html
+++ b/static/index.html
@@ -1079,27 +1079,72 @@
           <div class="mt-4 rounded-2xl border border-white/10 bg-white/5 p-4" id="spotify-card">
             <div class="flex items-center justify-between gap-3 flex-wrap">
               <div>
-                <div class="text-xs font-semibold uppercase tracking-[0.16em] text-emerald-300">Spotify import (optional)</div>
+                <div class="text-xs font-semibold uppercase tracking-[0.16em] text-emerald-300">Spotify (optional)</div>
                 <div class="mt-1 text-sm text-stone-300">
-                  Upload your <em>Spotify Extended Streaming History</em> to use it as the primary source.
-                  <a class="text-emerald-300 hover:text-emerald-200 underline" href="https://www.spotify.com/account/privacy/" target="_blank" rel="noreferrer">Request your data &rarr;</a>
+                  Log in with Spotify to use your listening data alongside Last.fm. Same login on any device.
                 </div>
               </div>
               <div id="spotify-status" class="text-xs text-stone-400">Not connected</div>
             </div>
-            <div id="spotify-form" class="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
-              <input id="spotify-profile-input" class="field-input flex-1 px-3 py-2 text-sm" type="text" placeholder="Display name (e.g. your Spotify username)" autocomplete="off" />
-              <input id="spotify-files-input" class="text-xs text-stone-300 file:mr-3 file:rounded-md file:border-0 file:bg-emerald-600/80 file:px-3 file:py-2 file:text-xs file:text-white hover:file:bg-emerald-500" type="file" accept=".json,.zip" multiple />
-              <button id="spotify-upload-btn" class="primary-button px-4 py-2 text-sm" type="button">Upload</button>
+
+            <!-- Logged-out state: Login button -->
+            <div id="spotify-login-section" class="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div class="text-xs text-stone-400">
+                We'll only ask for read access to your profile and recent plays.
+              </div>
+              <button id="spotify-login-btn" type="button"
+                class="inline-flex items-center gap-2 rounded-full bg-[#1DB954] px-4 py-2 text-sm font-semibold text-black hover:bg-[#1ed760] disabled:opacity-50">
+                <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true" fill="currentColor"><path d="M12 0a12 12 0 1 0 0 24 12 12 0 0 0 0-24zm5.5 17.3a.75.75 0 0 1-1 .25c-2.8-1.7-6.3-2-10.4-1.1a.75.75 0 1 1-.3-1.5c4.5-1 8.4-.6 11.5 1.3.4.3.5.7.2 1zm1.5-3.4a.94.94 0 0 1-1.3.3c-3.2-2-8-2.5-11.8-1.4a.94.94 0 1 1-.5-1.8c4.4-1.3 9.7-.7 13.4 1.6.4.3.6.9.2 1.3zm.1-3.5C15.4 8.3 8.5 8 5 9.1A1.13 1.13 0 1 1 4.4 7c4-1.2 11.6-1 15.7 1.5a1.13 1.13 0 0 1-1 2z"/></svg>
+                <span>Log in with Spotify</span>
+              </button>
             </div>
-            <div id="spotify-upload-status" class="mt-2 text-xs text-stone-400" aria-live="polite"></div>
-            <div id="spotify-upload-progress" class="mt-1 hidden">
-              <div class="h-1.5 w-full overflow-hidden rounded-full bg-white/10"><div id="spotify-upload-bar" class="h-full w-0 bg-emerald-500 transition-all"></div></div>
+
+            <!-- OAuth-not-configured state: shown when the server has no Spotify credentials. -->
+            <div id="spotify-not-configured" class="mt-3 hidden rounded-xl border border-amber-400/30 bg-amber-500/10 p-3 text-xs text-amber-100">
+              <div class="font-semibold text-amber-200">Spotify login not configured on this server.</div>
+              <div class="mt-1 text-amber-100/80">
+                Set <code class="rounded bg-black/30 px-1">SPOTIFY_CLIENT_ID</code>,
+                <code class="rounded bg-black/30 px-1">SPOTIFY_CLIENT_SECRET</code>,
+                <code class="rounded bg-black/30 px-1">SPOTIFY_REDIRECT_URI</code> and
+                <code class="rounded bg-black/30 px-1">SPOTIFY_TOKEN_ENCRYPTION_KEY</code>
+                in your <code class="rounded bg-black/30 px-1">.env</code> and restart. See the README for setup steps.
+              </div>
             </div>
-            <div id="spotify-connected" class="mt-3 hidden flex items-center justify-between gap-3 flex-wrap">
-              <div class="text-sm text-stone-200" id="spotify-connected-text"></div>
-              <button id="spotify-disconnect-btn" class="ghost-button px-3 py-1.5 text-xs" type="button">Clear &amp; disconnect</button>
+
+            <!-- Logged-in state: profile + actions -->
+            <div id="spotify-account" class="mt-3 hidden flex-col gap-3">
+              <div class="flex items-center gap-3 flex-wrap">
+                <img id="spotify-avatar" src="" alt="" class="h-10 w-10 rounded-full bg-white/10 object-cover hidden" />
+                <div class="flex-1 min-w-0">
+                  <div class="text-sm font-medium text-white truncate" id="spotify-account-name">—</div>
+                  <div class="text-xs text-stone-400 truncate" id="spotify-account-stats"></div>
+                </div>
+                <div class="flex items-center gap-2 flex-wrap">
+                  <button id="spotify-sync-btn" type="button" class="ghost-button px-3 py-1.5 text-xs">Sync recent plays</button>
+                  <button id="spotify-clear-btn" type="button" class="ghost-button px-3 py-1.5 text-xs">Clear my data</button>
+                  <button id="spotify-logout-btn" type="button" class="ghost-button px-3 py-1.5 text-xs">Log out</button>
+                </div>
+              </div>
+
+              <div class="rounded-lg border border-white/10 bg-black/20 p-3">
+                <div class="text-xs font-semibold text-stone-200">Backfill multi-year history</div>
+                <div class="mt-1 text-xs text-stone-400">
+                  Spotify only exposes the ~50 most-recent plays via API. Upload your
+                  <em>Extended Streaming History</em> to get years of data.
+                  <a class="text-emerald-300 hover:text-emerald-200 underline" href="https://www.spotify.com/account/privacy/" target="_blank" rel="noreferrer">Request your export &rarr;</a>
+                </div>
+                <div id="spotify-form" class="mt-2 flex flex-col gap-2 sm:flex-row sm:items-center">
+                  <input id="spotify-files-input" class="text-xs text-stone-300 file:mr-3 file:rounded-md file:border-0 file:bg-emerald-600/80 file:px-3 file:py-2 file:text-xs file:text-white hover:file:bg-emerald-500" type="file" accept=".json,.zip" multiple />
+                  <button id="spotify-upload-btn" class="primary-button px-4 py-2 text-sm" type="button">Upload</button>
+                </div>
+                <div id="spotify-upload-status" class="mt-2 text-xs text-stone-400" aria-live="polite"></div>
+                <div id="spotify-upload-progress" class="mt-1 hidden">
+                  <div class="h-1.5 w-full overflow-hidden rounded-full bg-white/10"><div id="spotify-upload-bar" class="h-full w-0 bg-emerald-500 transition-all"></div></div>
+                </div>
+              </div>
             </div>
+
+            <div id="spotify-error" class="mt-3 hidden rounded-md border border-red-500/40 bg-red-500/10 p-2 text-xs text-red-200" aria-live="polite"></div>
           </div>
         </div>
 
@@ -1237,24 +1282,35 @@
     let configOk = false;
     let currentUsername = '';
 
-    // Spotify connection state
+    // Spotify connection state. Identity comes from the server-side session
+    // cookie set by /api/spotify/callback; the JS never touches the cookie.
+    let spotifyLoggedIn = false;
     let spotifyProfileId = '';
-    let spotifyToken = '';
+    let spotifyDisplayName = '';
+    let spotifyAvatarUrl = '';
     let spotifyHasData = false;
     let spotifyStats = null;
+    let spotifyOAuthConfigured = false;
 
     const spotifyCard = document.getElementById('spotify-card');
+    const spotifyLoginSection = document.getElementById('spotify-login-section');
+    const spotifyNotConfigured = document.getElementById('spotify-not-configured');
+    const spotifyLoginBtn = document.getElementById('spotify-login-btn');
+    const spotifyAccount = document.getElementById('spotify-account');
+    const spotifyAccountName = document.getElementById('spotify-account-name');
+    const spotifyAccountStats = document.getElementById('spotify-account-stats');
+    const spotifyAvatar = document.getElementById('spotify-avatar');
+    const spotifySyncBtn = document.getElementById('spotify-sync-btn');
+    const spotifyClearBtn = document.getElementById('spotify-clear-btn');
+    const spotifyLogoutBtn = document.getElementById('spotify-logout-btn');
     const spotifyForm = document.getElementById('spotify-form');
-    const spotifyProfileInput = document.getElementById('spotify-profile-input');
     const spotifyFilesInput = document.getElementById('spotify-files-input');
     const spotifyUploadBtn = document.getElementById('spotify-upload-btn');
     const spotifyUploadStatus = document.getElementById('spotify-upload-status');
     const spotifyUploadProgress = document.getElementById('spotify-upload-progress');
     const spotifyUploadBar = document.getElementById('spotify-upload-bar');
     const spotifyStatusEl = document.getElementById('spotify-status');
-    const spotifyConnected = document.getElementById('spotify-connected');
-    const spotifyConnectedText = document.getElementById('spotify-connected-text');
-    const spotifyDisconnectBtn = document.getElementById('spotify-disconnect-btn');
+    const spotifyErrorEl = document.getElementById('spotify-error');
 
     const loadingScreen = document.getElementById('loading-screen');
     const yearCounter = document.getElementById('year-counter');
@@ -1561,8 +1617,16 @@
           connectBtn.disabled = true;
         } else {
           configOk = true;
-          // Auto-reconnect Spotify if cookies are present.
-          await tryAutoReconnectSpotify();
+          // Surface any OAuth error redirected back from /api/spotify/callback.
+          const params = new URLSearchParams(location.search);
+          const oauthErr = params.get('spotify_error');
+          if (oauthErr) {
+            showSpotifyError(`Spotify login failed: ${oauthErr}`);
+            // Strip the query so a refresh doesn't keep showing it.
+            history.replaceState(null, '', location.pathname);
+          }
+          // Refresh Spotify session state from the server (cookie is HttpOnly).
+          await refreshSpotifyStatus();
           const saved = getCookie('lastfm_username');
           if (saved) {
             usernameInput.value = saved;
@@ -1578,49 +1642,80 @@
       }
     })();
 
-    async function tryAutoReconnectSpotify() {
-      const profileId = getCookie('spotify_profile_id');
-      const token = getCookie('spotify_token');
-      if (!profileId || !token) return;
+    async function refreshSpotifyStatus() {
       try {
-        const res = await fetch(`/api/spotify/status?profile_id=${encodeURIComponent(profileId)}`, {
-          headers: { 'X-Spotify-Token': token },
-        });
-        if (!res.ok) {
-          // Stale cookie — clear it.
-          setCookie('spotify_profile_id', '', -1);
-          setCookie('spotify_token', '', -1);
-          return;
-        }
+        const res = await fetch('/api/spotify/status');
+        if (!res.ok) return;
         const body = await res.json();
-        if (body.ok) {
-          spotifyProfileId = profileId;
-          spotifyToken = token;
+        if (!body.ok) return;
+        spotifyOAuthConfigured = !!body.oauth_configured;
+        spotifyLoggedIn = !!body.logged_in;
+        if (spotifyLoggedIn) {
+          spotifyProfileId = body.profile_id || '';
+          spotifyDisplayName = body.display_name || spotifyProfileId;
+          spotifyAvatarUrl = body.avatar_url || '';
           spotifyHasData = !!body.has_data;
           spotifyStats = body.stats || null;
-          renderSpotifyConnected();
+        } else {
+          spotifyProfileId = '';
+          spotifyDisplayName = '';
+          spotifyAvatarUrl = '';
+          spotifyHasData = false;
+          spotifyStats = null;
         }
+        renderSpotifyCard();
       } catch {
-        // network error; ignore and let the user re-upload if needed.
+        // Network blip — leave UI as-is.
       }
     }
 
-    function renderSpotifyConnected() {
-      if (!spotifyProfileId || !spotifyToken) {
-        spotifyForm.classList.remove('hidden');
-        spotifyConnected.classList.add('hidden');
-        spotifyStatusEl.textContent = 'Not connected';
+    function renderSpotifyCard() {
+      // Always show the card so users see the Spotify section exists, even
+      // when OAuth isn't configured on the server.
+      spotifyCard.classList.remove('hidden');
+      if (!spotifyOAuthConfigured) {
+        spotifyLoginSection.classList.add('hidden');
+        spotifyAccount.classList.add('hidden');
+        spotifyAccount.classList.remove('flex');
+        spotifyNotConfigured.classList.remove('hidden');
+        spotifyStatusEl.textContent = 'Not configured';
+        spotifyStatusEl.classList.remove('text-emerald-300');
         return;
       }
-      spotifyForm.classList.add('hidden');
-      spotifyConnected.classList.remove('hidden');
-      spotifyConnected.classList.add('flex');
-      const totals = spotifyStats
+      spotifyNotConfigured.classList.add('hidden');
+      if (!spotifyLoggedIn) {
+        spotifyLoginSection.classList.remove('hidden');
+        spotifyAccount.classList.add('hidden');
+        spotifyAccount.classList.remove('flex');
+        spotifyStatusEl.textContent = 'Not connected';
+        spotifyStatusEl.classList.remove('text-emerald-300');
+        return;
+      }
+      spotifyLoginSection.classList.add('hidden');
+      spotifyAccount.classList.remove('hidden');
+      spotifyAccount.classList.add('flex');
+      spotifyAccountName.textContent = spotifyDisplayName;
+      const totals = spotifyStats && spotifyStats.total_plays
         ? `${spotifyStats.total_plays.toLocaleString()} plays · ${spotifyStats.unique_tracks.toLocaleString()} tracks · ${spotifyStats.unique_artists.toLocaleString()} artists`
-        : '';
-      spotifyConnectedText.textContent = `Spotify: ${spotifyProfileId}${totals ? ' — ' + totals : ''}`;
+        : 'No imported data yet';
+      spotifyAccountStats.textContent = totals;
+      if (spotifyAvatarUrl) {
+        spotifyAvatar.src = spotifyAvatarUrl;
+        spotifyAvatar.classList.remove('hidden');
+      } else {
+        spotifyAvatar.classList.add('hidden');
+      }
       spotifyStatusEl.textContent = '✓ Connected';
       spotifyStatusEl.classList.add('text-emerald-300');
+    }
+
+    function showSpotifyError(msg) {
+      spotifyErrorEl.textContent = msg;
+      spotifyErrorEl.classList.remove('hidden');
+    }
+    function clearSpotifyError() {
+      spotifyErrorEl.textContent = '';
+      spotifyErrorEl.classList.add('hidden');
     }
 
     function enterSearchMode() {
@@ -1628,33 +1723,79 @@
       howItWorks.style.display = 'none';
     }
 
-    spotifyUploadBtn.addEventListener('click', () => uploadSpotifyFiles());
-
-    spotifyDisconnectBtn.addEventListener('click', async () => {
-      if (!spotifyProfileId || !spotifyToken) return;
-      if (!confirm('Clear all imported Spotify data and disconnect?')) return;
-      try {
-        await fetch(`/api/spotify/data?profile_id=${encodeURIComponent(spotifyProfileId)}&delete_profile=true`, {
-          method: 'DELETE',
-          headers: { 'X-Spotify-Token': spotifyToken },
-        });
-      } catch {}
-      setCookie('spotify_profile_id', '', -1);
-      setCookie('spotify_token', '', -1);
-      spotifyProfileId = '';
-      spotifyToken = '';
-      spotifyHasData = false;
-      spotifyStats = null;
-      renderSpotifyConnected();
+    spotifyLoginBtn.addEventListener('click', () => {
+      clearSpotifyError();
+      // Full-page navigation so the OAuth state cookie / session cookie are
+      // set on the same origin without needing CORS gymnastics.
+      window.location.href = '/api/spotify/login';
     });
 
+    spotifyLogoutBtn.addEventListener('click', async () => {
+      try {
+        await fetch('/api/spotify/logout', { method: 'POST' });
+      } catch {}
+      spotifyLoggedIn = false;
+      spotifyProfileId = '';
+      spotifyDisplayName = '';
+      spotifyAvatarUrl = '';
+      spotifyHasData = false;
+      spotifyStats = null;
+      renderSpotifyCard();
+    });
+
+    spotifyClearBtn.addEventListener('click', async () => {
+      if (!spotifyLoggedIn) return;
+      if (!confirm('Delete all your imported Spotify plays from this server? You will stay logged in.')) return;
+      try {
+        const res = await fetch('/api/spotify/data', { method: 'DELETE' });
+        const body = await res.json().catch(() => ({}));
+        if (res.ok && body.ok) {
+          spotifyHasData = false;
+          spotifyStats = null;
+          renderSpotifyCard();
+        } else {
+          showSpotifyError(body.error || `Could not clear data (HTTP ${res.status}).`);
+        }
+      } catch {
+        showSpotifyError('Could not reach the server.');
+      }
+    });
+
+    spotifySyncBtn.addEventListener('click', async () => {
+      if (!spotifyLoggedIn) return;
+      clearSpotifyError();
+      const original = spotifySyncBtn.textContent;
+      spotifySyncBtn.disabled = true;
+      spotifySyncBtn.textContent = 'Syncing…';
+      try {
+        const res = await fetch('/api/spotify/sync', { method: 'POST' });
+        const body = await res.json().catch(() => ({}));
+        if (res.ok && body.ok) {
+          spotifyStats = body.stats || spotifyStats;
+          spotifyHasData = (spotifyStats && spotifyStats.total_plays > 0) || spotifyHasData;
+          renderSpotifyCard();
+          spotifyUploadStatus.textContent =
+            `Sync done: fetched ${body.fetched} recent plays, added ${body.imported} new (${body.filtered} filtered).`;
+        } else {
+          showSpotifyError(body.error || `Sync failed (HTTP ${res.status}).`);
+        }
+      } catch {
+        showSpotifyError('Could not reach the server.');
+      } finally {
+        spotifySyncBtn.disabled = false;
+        spotifySyncBtn.textContent = original;
+      }
+    });
+
+    spotifyUploadBtn.addEventListener('click', () => uploadSpotifyFiles());
+
     async function uploadSpotifyFiles() {
-      const profileId = (spotifyProfileInput.value || spotifyProfileId || '').trim();
-      const files = Array.from(spotifyFilesInput.files || []);
-      if (!profileId) {
-        spotifyUploadStatus.textContent = 'Enter a display name first.';
+      if (!spotifyLoggedIn) {
+        showSpotifyError('Log in with Spotify first.');
         return;
       }
+      clearSpotifyError();
+      const files = Array.from(spotifyFilesInput.files || []);
       if (!files.length) {
         spotifyUploadStatus.textContent = 'Select at least one .json or .zip file.';
         return;
@@ -1666,7 +1807,6 @@
       }
 
       const fd = new FormData();
-      fd.append('profile_id', profileId);
       files.forEach((f) => fd.append('files', f));
 
       spotifyUploadBtn.disabled = true;
@@ -1675,11 +1815,8 @@
       spotifyUploadBar.style.width = '0%';
 
       const xhr = new XMLHttpRequest();
-      const url = '/api/spotify/upload';
-      xhr.open('POST', url);
-      if (spotifyToken && spotifyProfileId === profileId) {
-        xhr.setRequestHeader('X-Spotify-Token', spotifyToken);
-      }
+      xhr.open('POST', '/api/spotify/upload');
+      // Cookie is sent automatically; no header needed.
       const switchToProcessing = () => {
         spotifyUploadBar.style.width = '100%';
         spotifyUploadBar.classList.add('bar-processing');
@@ -1695,25 +1832,14 @@
           }
         }
       };
-      xhr.upload.onload = () => {
-        // All bytes sent; the server is now parsing & importing.
-        switchToProcessing();
-      };
+      xhr.upload.onload = () => switchToProcessing();
       xhr.onload = () => {
         let body;
         try { body = JSON.parse(xhr.responseText); } catch { body = null; }
         if (xhr.status === 202 && body && body.ok && body.job_id) {
-          // Async path: stash the issued token (if any) and start polling.
-          if (body.token) {
-            spotifyToken = body.token;
-            setCookie('spotify_token', spotifyToken);
-          }
-          spotifyProfileId = profileId;
-          setCookie('spotify_profile_id', spotifyProfileId);
-          pollSpotifyImport(body.job_id, profileId);
+          pollSpotifyImport(body.job_id);
           return;
         }
-        // Either a synchronous error response (4xx/5xx) or an unexpected shape.
         spotifyUploadBtn.disabled = false;
         spotifyUploadBar.classList.remove('bar-processing');
         const msg = (body && body.error) || `Upload failed (HTTP ${xhr.status}).`;
@@ -1727,10 +1853,7 @@
       xhr.send(fd);
     }
 
-    async function pollSpotifyImport(jobId, profileId) {
-      // Poll every 1.5s until the worker reports done/error. The server keeps
-      // job state for ~10 min after completion so transient network blips are
-      // recoverable.
+    async function pollSpotifyImport(jobId) {
       const filteredTip = `<span class="info-tip" title="Plays excluded from import: podcasts/audiobooks (no track metadata) and very short plays (under 30 seconds). This matches Spotify's own counting threshold." aria-label="What does filtered mean?">?</span>`;
       let lastError = '';
       while (true) {
@@ -1761,7 +1884,7 @@
           spotifyUploadStatus.innerHTML =
             `Imported <strong>${imported.toLocaleString()}</strong> plays from ${filesDone} ${fileWord} ` +
             `(<strong>${filtered.toLocaleString()}</strong> filtered${filteredTip}).`;
-          renderSpotifyConnected();
+          renderSpotifyCard();
           enterSearchMode();
           return;
         }
@@ -1772,7 +1895,6 @@
           return;
         }
 
-        // Still importing — show live counts.
         const fileMsg = filesTotal > 1 ? ` · file ${Math.min(filesDone + 1, filesTotal)}/${filesTotal}` : '';
         const currentFile = payload.current_file ? ` (${payload.current_file.split('::').pop()})` : '';
         spotifyUploadStatus.textContent =
@@ -2071,10 +2193,9 @@
         if (currentUsername) {
           tasks.push(fetch(`/api/search?q=${encodeURIComponent(query)}`).then(r => r.json()).catch(() => []));
         }
-        if (spotifyProfileId && spotifyToken) {
-          tasks.push(fetch(`/api/spotify/search?profile_id=${encodeURIComponent(spotifyProfileId)}&q=${encodeURIComponent(query)}`, {
-            headers: { 'X-Spotify-Token': spotifyToken },
-          }).then(r => r.ok ? r.json() : []).catch(() => []));
+        if (spotifyLoggedIn) {
+          tasks.push(fetch(`/api/spotify/search?q=${encodeURIComponent(query)}`)
+            .then(r => r.ok ? r.json() : []).catch(() => []));
         }
         if (!tasks.length) {
           hideAC();
@@ -2087,7 +2208,7 @@
         let spotifyResults = [];
         let i = 0;
         if (currentUsername) { lastfmResults = results[i++] || []; }
-        if (spotifyProfileId && spotifyToken) { spotifyResults = results[i++] || []; }
+        if (spotifyLoggedIn) { spotifyResults = results[i++] || []; }
 
         // Tag sources, dedupe by normalized track+artist (Spotify wins if connected)
         const seen = new Set();
@@ -2168,15 +2289,13 @@
         if (currentUsername) {
           firstListenUrl += `&username=${encodeURIComponent(currentUsername)}`;
         }
-        if (spotifyProfileId) {
+        if (spotifyLoggedIn && spotifyProfileId) {
           firstListenUrl += `&profile_id=${encodeURIComponent(spotifyProfileId)}`;
         }
         if (track.hintTimestamp) {
           firstListenUrl += `&hint_timestamp=${encodeURIComponent(track.hintTimestamp)}`;
         }
-        const headers = {};
-        if (spotifyToken) headers['X-Spotify-Token'] = spotifyToken;
-        const res = await fetch(firstListenUrl, { headers });
+        const res = await fetch(firstListenUrl);
         const body = await res.json();
 
         let data;
@@ -2425,15 +2544,13 @@
     async function fetchAndRenderArtistFirstListen(artist) {
       const contentEl = document.getElementById('artist-first-listen-content');
       if (!contentEl) return;
-      if (!currentUsername && !spotifyProfileId) return;
+      if (!currentUsername && !spotifyLoggedIn) return;
 
       try {
         let url = `/api/artist-first-listen?artist=${encodeURIComponent(artist)}`;
         if (currentUsername) url += `&username=${encodeURIComponent(currentUsername)}`;
-        if (spotifyProfileId) url += `&profile_id=${encodeURIComponent(spotifyProfileId)}`;
-        const headers = {};
-        if (spotifyToken) headers['X-Spotify-Token'] = spotifyToken;
-        const res = await fetch(url, { headers });
+        if (spotifyLoggedIn && spotifyProfileId) url += `&profile_id=${encodeURIComponent(spotifyProfileId)}`;
+        const res = await fetch(url);
         const data = await res.json();
 
         if (data.error) {

--- a/test_app.py
+++ b/test_app.py
@@ -1227,13 +1227,76 @@ class TestArtistFirstListenAutoUpdate:
         assert result["first_listen_date"] == earliest_date[0]
 
 
+
 # ---------------------------------------------------------------------------
 # Spotify integration tests
 # ---------------------------------------------------------------------------
 
+import io as _io  # noqa: E402
+import zipfile  # noqa: E402
+
+# Stable Fernet key for tests (32-byte url-safe base64). The real value comes
+# from SPOTIFY_TOKEN_ENCRYPTION_KEY in production.
+_TEST_FERNET_KEY = "Nwly3UgU6NMXjqGGXt4tvO2eL-L-3gabdD_v3hBcvCU="
+
+
+@pytest.fixture
+def spotify_oauth_env(monkeypatch):
+    """Make _spotify_oauth_configured() return True for tests.
+
+    Patches the module-level constants that app.py reads at import time so
+    /api/spotify/login etc. don't 503.
+    """
+    monkeypatch.setattr(app_module, "SPOTIFY_CLIENT_ID", "test-client-id")
+    monkeypatch.setattr(app_module, "SPOTIFY_CLIENT_SECRET", "test-client-secret")
+    monkeypatch.setattr(app_module, "SPOTIFY_REDIRECT_URI", "http://localhost/api/spotify/callback")
+    monkeypatch.setattr(app_module, "SPOTIFY_TOKEN_ENCRYPTION_KEY", _TEST_FERNET_KEY)
+    # Reset in-memory caches between tests.
+    with app_module.SPOTIFY_OAUTH_PENDING_LOCK:
+        app_module.SPOTIFY_OAUTH_PENDING.clear()
+    with app_module.SPOTIFY_ACCESS_TOKENS_LOCK:
+        app_module.SPOTIFY_ACCESS_TOKENS.clear()
+    yield
+
+
+def _login_spotify(client, user_id, *, display_name=None, avatar_url=""):
+    """Walk the OAuth flow end-to-end with mocked Spotify endpoints."""
+    display_name = display_name or user_id
+
+    login_resp = client.get("/api/spotify/login")
+    assert login_resp.status_code == 302
+    location = login_resp.headers["Location"]
+    from urllib.parse import urlparse, parse_qs
+    qs = parse_qs(urlparse(location).query)
+    state = qs["state"][0]
+
+    fake_token = {
+        "access_token": f"access-{user_id}",
+        "refresh_token": f"refresh-{user_id}",
+        "expires_in": 3600,
+        "scope": app_module.SPOTIFY_OAUTH_SCOPES,
+    }
+    me_payload = {
+        "id": user_id,
+        "display_name": display_name,
+        "email": f"{user_id}@example.com",
+        "images": ([{"url": avatar_url}] if avatar_url else []),
+    }
+
+    class _FakeMeResp:
+        status_code = 200
+
+        def json(self):
+            return me_payload
+
+    with patch.object(app_module, "_spotify_request_token", return_value=fake_token), \
+         patch.object(app_module.requests, "get", return_value=_FakeMeResp()):
+        cb = client.get(f"/api/spotify/callback?code=fake-code&state={state}")
+    assert cb.status_code == 302, cb.get_data(as_text=True)
+    return user_id
+
 
 def _spotify_entry(ts, track="Spot Track", artist="Spot Artist", album="Spot Album", ms_played=60000):
-    """Build a single Spotify Extended Streaming History entry."""
     return {
         "ts": ts,
         "platform": "test",
@@ -1244,57 +1307,35 @@ def _spotify_entry(ts, track="Spot Track", artist="Spot Artist", album="Spot Alb
     }
 
 
-def _spotify_upload(client, profile_id, entries, *, token=None, filename="Streaming_History_Audio_2010.json"):
-    """POST a synthetic Spotify JSON file to /api/spotify/upload and wait for the
-    background import job to finish.
-
-    The endpoint returns 202 + job_id; we poll /api/spotify/import-progress until
-    the worker finishes, then return a wrapper response object whose `status_code`,
-    `get_json()` and `headers` mimic the old synchronous response shape (so the
-    test assertions stay readable).
-    """
-    import io as _io
-    import time as _time
-
+def _spotify_upload(client, entries, *, filename="Streaming_History_Audio_2010.json"):
     buf = _io.BytesIO(json.dumps(entries).encode("utf-8"))
-    headers = {}
-    if token:
-        headers["X-Spotify-Token"] = token
     post_resp = client.post(
         "/api/spotify/upload",
-        data={"profile_id": profile_id, "files": (buf, filename)},
+        data={"files": (buf, filename)},
         content_type="multipart/form-data",
-        headers=headers,
     )
     return _await_spotify_import(client, post_resp)
 
 
 def _await_spotify_import(client, post_resp, *, timeout=10.0):
-    """Wait for an async Spotify import to finish and return a flattened response."""
-    import time as _time
-
     if post_resp.status_code != 202:
-        return post_resp  # pre-flight error (4xx/5xx) — return as-is
+        return post_resp
 
     post_body = post_resp.get_json() or {}
     job_id = post_body.get("job_id")
-    deadline = _time.time() + timeout
+    deadline = time.time() + timeout
     final = None
-    while _time.time() < deadline:
+    while time.time() < deadline:
         prog = client.get(f"/api/spotify/import-progress?job_id={job_id}")
         payload = prog.get_json() or {}
         if payload.get("stage") in ("done", "error"):
             final = payload
             break
-        _time.sleep(0.02)
+        time.sleep(0.02)
     assert final is not None, f"spotify import job {job_id} did not finish within {timeout}s"
 
     if final.get("stage") == "error":
-        flat = {
-            "ok": False,
-            "error": final.get("error") or "Import failed",
-            "job_id": job_id,
-        }
+        flat = {"ok": False, "error": final.get("error") or "Import failed", "job_id": job_id}
         status_code = 500
     else:
         flat = {
@@ -1305,8 +1346,6 @@ def _await_spotify_import(client, post_resp, *, timeout=10.0):
             "stats": final.get("stats", {}),
             "job_id": job_id,
         }
-        if "token" in post_body:
-            flat["token"] = post_body["token"]
         status_code = 200
 
     class _SyntheticResponse:
@@ -1321,62 +1360,115 @@ def _await_spotify_import(client, post_resp, *, timeout=10.0):
     return _SyntheticResponse(status_code, flat, post_resp.headers)
 
 
+# ----- OAuth flow tests -----
+
+
+class TestSpotifyOAuth:
+    def test_login_redirects_to_authorize_url(self, client, spotify_oauth_env):
+        resp = client.get("/api/spotify/login")
+        assert resp.status_code == 302
+        loc = resp.headers["Location"]
+        assert loc.startswith(app_module.SPOTIFY_OAUTH_AUTHORIZE_URL)
+        from urllib.parse import urlparse, parse_qs
+        qs = parse_qs(urlparse(loc).query)
+        assert qs["client_id"] == ["test-client-id"]
+        assert qs["response_type"] == ["code"]
+        assert qs["code_challenge_method"] == ["S256"]
+        assert qs["state"][0]
+        assert qs["code_challenge"][0]
+
+    def test_login_returns_503_when_oauth_not_configured(self, client):
+        with patch.object(app_module, "SPOTIFY_CLIENT_ID", ""):
+            resp = client.get("/api/spotify/login")
+        assert resp.status_code == 503
+
+    def test_callback_creates_session_and_profile(self, client, spotify_oauth_env):
+        _login_spotify(client, "alice", display_name="Alice")
+        status = client.get("/api/spotify/status").get_json()
+        assert status["ok"] is True
+        assert status["logged_in"] is True
+        assert status["profile_id"] == "alice"
+        assert status["display_name"] == "Alice"
+        profile = database.get_spotify_profile("alice")
+        assert profile is not None
+        assert profile["display_name"] == "Alice"
+        assert profile["refresh_token_encrypted"]
+        assert profile["refresh_token_encrypted"] != "refresh-alice"
+
+    def test_callback_rejects_unknown_state(self, client, spotify_oauth_env):
+        resp = client.get("/api/spotify/callback?code=x&state=does-not-exist")
+        assert resp.status_code == 400
+
+    def test_logout_clears_session(self, client, spotify_oauth_env):
+        _login_spotify(client, "bob")
+        assert client.get("/api/spotify/status").get_json()["logged_in"] is True
+        out = client.post("/api/spotify/logout")
+        assert out.status_code == 200
+        assert client.get("/api/spotify/status").get_json()["logged_in"] is False
+
+
+# ----- Upload + import tests -----
+
+
 class TestSpotifyUpload:
-    def test_first_upload_creates_profile_and_returns_token(self, client):
+    def test_upload_requires_session(self, client, spotify_oauth_env):
+        resp = client.post(
+            "/api/spotify/upload",
+            data={"files": (_io.BytesIO(b"[]"), "x.json")},
+            content_type="multipart/form-data",
+        )
+        assert resp.status_code == 401
+
+    def test_first_upload_imports_plays(self, client, spotify_oauth_env):
+        _login_spotify(client, "alice")
         entries = [
             _spotify_entry("2010-09-09T11:46:34Z"),
             _spotify_entry("2011-01-02T08:00:00Z"),
         ]
-        resp = _spotify_upload(client, "alice", entries)
+        resp = _spotify_upload(client, entries)
         assert resp.status_code == 200
-        data = resp.get_json()
-        assert data["ok"] is True
-        assert data["imported"] == 2
-        assert data["filtered"] == 0
-        assert "token" in data and len(data["token"]) > 20
-        assert data["stats"]["total_plays"] == 2
-        # Cookie set on response
-        cookies = resp.headers.getlist("Set-Cookie")
-        assert any("spotify_token=" in c for c in cookies)
+        body = resp.get_json()
+        assert body["ok"] is True
+        assert body["imported"] == 2
+        assert body["filtered"] == 0
+        assert body["stats"]["total_plays"] == 2
 
-    def test_short_plays_and_podcasts_filtered(self, client):
+    def test_short_plays_and_podcasts_filtered(self, client, spotify_oauth_env):
+        _login_spotify(client, "alice")
         entries = [
             _spotify_entry("2012-02-02T00:00:00Z", ms_played=1000),  # too short
-            {"ts": "2012-02-03T00:00:00Z", "ms_played": 60000},  # podcast (no track name)
-            _spotify_entry("2012-02-04T00:00:00Z"),  # keep
+            {"ts": "2012-02-03T00:00:00Z", "ms_played": 60000},      # podcast
+            _spotify_entry("2012-02-04T00:00:00Z"),                  # keep
         ]
-        resp = _spotify_upload(client, "alice2", entries)
-        data = resp.get_json()
+        resp = _spotify_upload(client, entries)
+        body = resp.get_json()
         assert resp.status_code == 200
-        assert data["imported"] == 1
-        assert data["filtered"] == 2
+        assert body["imported"] == 1
+        assert body["filtered"] == 2
 
-    def test_reupload_dedupes(self, client):
+    def test_reupload_dedupes(self, client, spotify_oauth_env):
+        _login_spotify(client, "alice")
         entries = [_spotify_entry("2010-09-09T11:46:34Z")]
-        first = _spotify_upload(client, "alice3", entries)
-        token = first.get_json()["token"]
-        second = _spotify_upload(client, "alice3", entries, token=token)
+        first = _spotify_upload(client, entries)
+        assert first.get_json()["imported"] == 1
+        second = _spotify_upload(client, entries)
         assert second.status_code == 200
-        assert second.get_json()["imported"] == 0  # nothing new
+        assert second.get_json()["imported"] == 0
         assert second.get_json()["stats"]["total_plays"] == 1
 
-    def test_reupload_without_token_is_forbidden(self, client):
-        _spotify_upload(client, "alice4", [_spotify_entry("2010-09-09T11:46:34Z")])
-        # Drop the cookie set by the first upload, simulating a fresh visitor.
-        client.delete_cookie("spotify_token", domain="localhost")
-        client.delete_cookie("spotify_profile_id", domain="localhost")
-        resp = client.post(
-            "/api/spotify/upload",
-            data={"profile_id": "alice4", "files": (
-                __import__("io").BytesIO(b"[]"),
-                "Streaming_History_Audio_x.json",
-            )},
-            content_type="multipart/form-data",
-        )
-        assert resp.status_code == 403
+    def test_each_user_isolated(self, client, spotify_oauth_env):
+        _login_spotify(client, "alice")
+        _spotify_upload(client, [_spotify_entry("2011-01-01T00:00:00Z", track="A_track")])
+        client.post("/api/spotify/logout")
+        _login_spotify(client, "bob")
+        status = client.get("/api/spotify/status").get_json()
+        assert status["has_data"] is False
+        _spotify_upload(client, [_spotify_entry("2012-02-02T00:00:00Z", track="B_track")])
+        results = client.get("/api/spotify/search?q=track").get_json()
+        assert all(r["name"] == "B_track" for r in results)
 
-    def test_zip_upload(self, client):
-        import io as _io
+    def test_zip_upload(self, client, spotify_oauth_env):
+        _login_spotify(client, "zipuser")
         entries = [
             _spotify_entry("2014-05-05T12:00:00Z", track="ZipTrack"),
             _spotify_entry("2015-06-06T12:00:00Z", track="ZipTrack"),
@@ -1392,7 +1484,7 @@ class TestSpotifyUpload:
         zip_buf.seek(0)
         post_resp = client.post(
             "/api/spotify/upload",
-            data={"profile_id": "zipuser", "files": (zip_buf, "spotify.zip")},
+            data={"files": (zip_buf, "spotify.zip")},
             content_type="multipart/form-data",
         )
         resp = _await_spotify_import(client, post_resp)
@@ -1402,132 +1494,45 @@ class TestSpotifyUpload:
         assert body["files_processed"] == 1
 
 
-class TestSpotifyAuth:
-    def test_status_requires_token(self, client):
-        upload = _spotify_upload(client, "bob", [_spotify_entry("2010-01-01T00:00:00Z")])
-        token = upload.get_json()["token"]
-        # Wrong token
-        resp = client.get("/api/spotify/status?profile_id=bob", headers={"X-Spotify-Token": "wrong"})
-        assert resp.status_code == 403
-        # Correct token
-        resp = client.get("/api/spotify/status?profile_id=bob", headers={"X-Spotify-Token": token})
+# ----- Authenticated endpoints -----
+
+
+class TestSpotifyAuthEndpoints:
+    def test_status_logged_out(self, client, spotify_oauth_env):
+        body = client.get("/api/spotify/status").get_json()
+        assert body["ok"] is True
+        assert body["logged_in"] is False
+        assert body["oauth_configured"] is True
+
+    def test_search_requires_session(self, client, spotify_oauth_env):
+        resp = client.get("/api/spotify/search?q=hello")
+        assert resp.status_code == 401
+
+    def test_clear_data_requires_session(self, client, spotify_oauth_env):
+        resp = client.delete("/api/spotify/data")
+        assert resp.status_code == 401
+
+    def test_sync_requires_session(self, client, spotify_oauth_env):
+        resp = client.post("/api/spotify/sync")
+        assert resp.status_code == 401
+
+    def test_clear_data_keeps_session(self, client, spotify_oauth_env):
+        _login_spotify(client, "carl")
+        _spotify_upload(client, [_spotify_entry("2010-01-01T00:00:00Z")])
+        resp = client.delete("/api/spotify/data")
         assert resp.status_code == 200
         body = resp.get_json()
-        assert body["has_data"] is True
-        assert body["stats"]["total_plays"] == 1
+        assert body["deleted"] == 1
+        assert body["profile_deleted"] is False
+        assert client.get("/api/spotify/status").get_json()["logged_in"] is True
 
-    def test_unknown_profile_returns_404(self, client):
-        resp = client.get("/api/spotify/status?profile_id=ghost")
-        assert resp.status_code == 404
-
-    def test_cross_user_isolation(self, client):
-        a = _spotify_upload(client, "userA", [_spotify_entry("2011-01-01T00:00:00Z", track="A_track")])
-        b = _spotify_upload(client, "userB", [_spotify_entry("2012-02-02T00:00:00Z", track="B_track")])
-        token_a = a.get_json()["token"]
-        token_b = b.get_json()["token"]
-        # userA's token cannot read userB's data
-        resp = client.get("/api/spotify/status?profile_id=userB", headers={"X-Spotify-Token": token_a})
-        assert resp.status_code == 403
-        # Each correct token works
-        ra = client.get("/api/spotify/search?profile_id=userA&q=A_track", headers={"X-Spotify-Token": token_a})
-        rb = client.get("/api/spotify/search?profile_id=userB&q=B_track", headers={"X-Spotify-Token": token_b})
-        assert ra.status_code == 200 and len(ra.get_json()) == 1
-        assert rb.status_code == 200 and len(rb.get_json()) == 1
-
-
-class TestSpotifyFirstListen:
-    def test_first_listen_uses_spotify_when_available(self, client):
-        entries = [
-            _spotify_entry("2014-05-05T12:00:00Z", track="MyTrack", artist="MyArtist"),
-            _spotify_entry("2010-03-04T08:00:00Z", track="MyTrack", artist="MyArtist"),
-            _spotify_entry("2018-08-08T20:00:00Z", track="MyTrack", artist="MyArtist"),
-        ]
-        upload = _spotify_upload(client, "spuser", entries)
-        token = upload.get_json()["token"]
-        resp = client.get(
-            "/api/first-listen?track=MyTrack&artist=MyArtist&profile_id=spuser",
-            headers={"X-Spotify-Token": token},
-        )
-        assert resp.status_code == 200
-        data = resp.get_json()
-        assert data["found"] is True
-        assert data["source"] == "spotify"
-        assert data["total_scrobbles"] == 3
-        # Earliest of the three
-        assert data["timestamp"] != ""
-        from datetime import datetime as _dt, timezone as _tz
-        assert _dt.fromtimestamp(int(data["timestamp"]), tz=_tz.utc).year == 2010
-
-    def test_first_listen_spotify_only_not_found(self, client):
-        upload = _spotify_upload(client, "spuser2", [_spotify_entry("2010-01-01T00:00:00Z", track="A", artist="B")])
-        token = upload.get_json()["token"]
-        resp = client.get(
-            "/api/first-listen?track=Other&artist=B&profile_id=spuser2",
-            headers={"X-Spotify-Token": token},
-        )
-        assert resp.status_code == 200
-        data = resp.get_json()
-        assert data["found"] is False
-        assert data["source"] == "spotify"
-
-    def test_first_listen_falls_back_to_lastfm_when_not_in_spotify(self, client):
-        upload = _spotify_upload(client, "spuser3", [_spotify_entry("2010-01-01T00:00:00Z", track="A", artist="B")])
-        token = upload.get_json()["token"]
-        # The track we ask about isn't in Spotify but Last.fm has it
-        with patch("app.lastfm_get") as mock_get:
-            mock_get.return_value = _track_info_response(0)
-            data, status = _await_first_listen(
-                client,
-                "track=Songname&artist=Artistname&username=lfmuser&profile_id=spuser3",
-                timeout=5,
-            )
-            client.set_cookie(domain="localhost", key="spotify_token", value=token)
-        # Returned 'no listens' result from Last.fm path
-        assert status == 200
-        assert data["found"] is False
-
-    def test_artist_first_listen_prefers_spotify(self, client):
-        entries = [
-            _spotify_entry("2013-04-04T12:00:00Z", track="Track1", artist="ArtistX"),
-            _spotify_entry("2010-01-01T00:00:00Z", track="Track2", artist="ArtistX"),
-        ]
-        upload = _spotify_upload(client, "spuser4", entries)
-        token = upload.get_json()["token"]
-        resp = client.get(
-            "/api/artist-first-listen?artist=ArtistX&profile_id=spuser4",
-            headers={"X-Spotify-Token": token},
-        )
-        assert resp.status_code == 200
-        body = resp.get_json()
-        assert body["source"] == "spotify"
-        assert body["first_listen_track"] == "Track2"
-
-
-class TestSpotifyClearAndSearch:
-    def test_clear_data_removes_history_keeps_profile(self, client):
-        upload = _spotify_upload(client, "carl", [_spotify_entry("2010-01-01T00:00:00Z")])
-        token = upload.get_json()["token"]
-        resp = client.delete(
-            "/api/spotify/data?profile_id=carl",
-            headers={"X-Spotify-Token": token},
-        )
-        assert resp.status_code == 200
-        assert resp.get_json()["deleted"] == 1
-        # Profile still exists, can re-upload
-        resp2 = _spotify_upload(client, "carl", [_spotify_entry("2010-01-01T00:00:00Z")], token=token)
-        assert resp2.status_code == 200
-        assert resp2.get_json()["imported"] == 1
-
-    def test_search_returns_imported_tracks(self, client):
-        upload = _spotify_upload(client, "dana", [
+    def test_search_returns_imported_tracks(self, client, spotify_oauth_env):
+        _login_spotify(client, "dana")
+        _spotify_upload(client, [
             _spotify_entry("2010-01-01T00:00:00Z", track="Hello World", artist="Greetings"),
             _spotify_entry("2010-01-02T00:00:00Z", track="Goodbye Sky", artist="Greetings"),
         ])
-        token = upload.get_json()["token"]
-        resp = client.get(
-            "/api/spotify/search?profile_id=dana&q=hello",
-            headers={"X-Spotify-Token": token},
-        )
+        resp = client.get("/api/spotify/search?q=hello")
         assert resp.status_code == 200
         results = resp.get_json()
         assert len(results) == 1
@@ -1535,6 +1540,87 @@ class TestSpotifyClearAndSearch:
         assert results[0]["source"] == "spotify"
 
 
-# zipfile is needed by the upload tests
-import zipfile  # noqa: E402
+# ----- Sync (recently-played) -----
 
+
+class TestSpotifySync:
+    def test_sync_imports_recently_played(self, client, spotify_oauth_env):
+        _login_spotify(client, "syncer")
+
+        recent_payload = {
+            "items": [
+                {
+                    "track": {
+                        "name": "Recent Track",
+                        "duration_ms": 200000,
+                        "artists": [{"name": "Recent Artist"}],
+                        "album": {"name": "Recent Album"},
+                    },
+                    "played_at": "2024-05-05T10:00:00.000Z",
+                }
+            ]
+        }
+
+        class _FakeResp:
+            status_code = 200
+
+            def json(self):
+                return recent_payload
+
+        with patch.object(app_module, "_get_valid_access_token", return_value="access-syncer"), \
+             patch.object(app_module.requests, "get", return_value=_FakeResp()):
+            resp = client.post("/api/spotify/sync")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["fetched"] == 1
+        assert body["imported"] == 1
+        assert body["stats"]["total_plays"] == 1
+        prof = database.get_spotify_profile("syncer")
+        assert prof.get("last_sync_at")
+
+    def test_sync_handles_401_from_spotify(self, client, spotify_oauth_env):
+        _login_spotify(client, "syncer2")
+
+        class _Fake401:
+            status_code = 401
+
+            def json(self):
+                return {}
+
+        with patch.object(app_module, "_get_valid_access_token", return_value="access-syncer2"), \
+             patch.object(app_module.requests, "get", return_value=_Fake401()):
+            resp = client.post("/api/spotify/sync")
+        assert resp.status_code == 401
+
+
+# ----- First-listen Spotify path -----
+
+
+class TestSpotifyFirstListen:
+    def test_first_listen_uses_spotify_when_available(self, client, spotify_oauth_env):
+        _login_spotify(client, "spuser")
+        _spotify_upload(client, [
+            _spotify_entry("2014-05-05T12:00:00Z", track="MyTrack", artist="MyArtist"),
+            _spotify_entry("2010-03-04T08:00:00Z", track="MyTrack", artist="MyArtist"),
+            _spotify_entry("2018-08-08T20:00:00Z", track="MyTrack", artist="MyArtist"),
+        ])
+        resp = client.get("/api/first-listen?track=MyTrack&artist=MyArtist")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["found"] is True
+        assert data["source"] == "spotify"
+        assert data["total_scrobbles"] == 3
+        from datetime import datetime as _dt, timezone as _tz
+        assert _dt.fromtimestamp(int(data["timestamp"]), tz=_tz.utc).year == 2010
+
+    def test_artist_first_listen_prefers_spotify(self, client, spotify_oauth_env):
+        _login_spotify(client, "spuser4")
+        _spotify_upload(client, [
+            _spotify_entry("2013-04-04T12:00:00Z", track="Track1", artist="ArtistX"),
+            _spotify_entry("2010-01-01T00:00:00Z", track="Track2", artist="ArtistX"),
+        ])
+        resp = client.get("/api/artist-first-listen?artist=ArtistX")
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["source"] == "spotify"
+        assert body["first_listen_track"] == "Track2"


### PR DESCRIPTION
- Introduced a fixture to configure Spotify OAuth environment for tests.
- Implemented tests for the OAuth login flow, including session creation and profile management.
- Refactored the `_spotify_upload` function to remove profile_id parameter and ensure user isolation during uploads.
- Enhanced tests for uploading and importing Spotify data, ensuring correct handling of short plays and podcasts.
- Added tests for authenticated endpoints, ensuring session management and data access control.
- Improved first-listen functionality tests to prefer Spotify data when available.
- Removed deprecated tests and cleaned up code for better readability and maintainability.